### PR TITLE
Re-added missing DLL_METASPLOIT_* defines

### DIFF
--- a/common/ReflectiveDLLInjection.h
+++ b/common/ReflectiveDLLInjection.h
@@ -33,6 +33,8 @@
 
 // we declare some common stuff in here...
 
+#define DLL_METASPLOIT_ATTACH	4
+#define DLL_METASPLOIT_DETACH	5
 #define DLL_QUERY_HMODULE		6
 
 #define DEREF( name )*(UINT_PTR *)(name)


### PR DESCRIPTION
I somehow poached these when I normalised the headers. Idiot.

Given that everyone is in bed, and this is such a small change, I'm going to merge this myself so I can carry on. Sorry guys!
