### PR TITLE
Fixed out-of-bounds read in fixing relocations

### DIFF
--- a/dll/src/ReflectiveLoader.c
+++ b/dll/src/ReflectiveLoader.c
@@ -443,11 +443,13 @@ DLLEXPORT ULONG_PTR WINAPI ReflectiveLoader( VOID )
 	// check if their are any relocations present
 	if( ((PIMAGE_DATA_DIRECTORY)uiValueB)->Size )
 	{
+		uiValueE = ((PIMAGE_BASE_RELOCATION)uiValueB)->SizeOfBlock;
+
 		// uiValueC is now the first entry (IMAGE_BASE_RELOCATION)
 		uiValueC = ( uiBaseAddress + ((PIMAGE_DATA_DIRECTORY)uiValueB)->VirtualAddress );
 
 		// and we itterate through all entries...
-		while( ((PIMAGE_BASE_RELOCATION)uiValueC)->SizeOfBlock )
+		while( uiValueE && ((PIMAGE_BASE_RELOCATION)uiValueC)->SizeOfBlock )
 		{
 			// uiValueA = the VA for this relocation block
 			uiValueA = ( uiBaseAddress + ((PIMAGE_BASE_RELOCATION)uiValueC)->VirtualAddress );
@@ -510,6 +512,7 @@ DLLEXPORT ULONG_PTR WINAPI ReflectiveLoader( VOID )
 				uiValueD += sizeof( IMAGE_RELOC );
 			}
 
+			uiValueE -= ((PIMAGE_BASE_RELOCATION)uiValueC)->SizeOfBlock;
 			// get the next entry in the relocation directory
 			uiValueC = uiValueC + ((PIMAGE_BASE_RELOCATION)uiValueC)->SizeOfBlock;
 		}


### PR DESCRIPTION
ReflectiveLoader's relocation fixing routine did not properly check if it had finished parsing each relocation block.
After parsing the last block, `uiValueC` would point to memory outside of the relocation table and during next `while( ((PIMAGE_BASE_RELOCATION)uiValueC)->SizeOfBlock )` condition, it would stop only if out-of-bounds read on DWORD following last relocation block, returned 0.

Bug was triggered randomly after recompilation of meterpreter's DLLs. Loop would continue parsing relocations using input from outside of relocation table data, leading to memory corruption.

Proposed fix introduces a variable that keeps track of total size of all relocation blocks to be parsed and subtracts the size of each relocation block after it is parsed. While loop's additional condition is to only continue if total size of blocks, yet to be parsed, is larger than 0.