### PR TITLE
Mingw/clang compatibility fixes.

### DIFF
--- a/dll/src/ReflectiveLoader.c
+++ b/dll/src/ReflectiveLoader.c
@@ -30,8 +30,10 @@
 // Our loader will set this to a pseudo correct HINSTANCE/HMODULE value
 HINSTANCE hAppInstance = NULL;
 //===============================================================================================//
-#pragma intrinsic( _ReturnAddress )
-// This function can not be inlined by the compiler or we will not get the address we expect. Ideally 
+#ifndef __MINGW32__
+#pragma intrinsic(_ReturnAddress)
+#endif 
+// This function can not be inlined by the compiler or we will not get the address we expect. Ideally
 // this code will be compiled with the /O2 and /Ob1 switches. Bonus points if we could take advantage of 
 // RIP relative addressing in this instance but I dont believe we can do so with the compiler intrinsics 
 // available (and no inline asm available under x64).

--- a/dll/src/ReflectiveLoader.c
+++ b/dll/src/ReflectiveLoader.c
@@ -1,28 +1,28 @@
 //===============================================================================================//
 // Copyright (c) 2013, Stephen Fewer of Harmony Security (www.harmonysecurity.com)
 // All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without modification, are permitted 
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted
 // provided that the following conditions are met:
-// 
-//     * Redistributions of source code must retain the above copyright notice, this list of 
+//
+//     * Redistributions of source code must retain the above copyright notice, this list of
 // conditions and the following disclaimer.
-// 
-//     * Redistributions in binary form must reproduce the above copyright notice, this list of 
-// conditions and the following disclaimer in the documentation and/or other materials provided 
+//
+//     * Redistributions in binary form must reproduce the above copyright notice, this list of
+// conditions and the following disclaimer in the documentation and/or other materials provided
 // with the distribution.
-// 
+//
 //     * Neither the name of Harmony Security nor the names of its contributors may be used to
 // endorse or promote products derived from this software without specific prior written permission.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR 
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
 // IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
-// FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR 
-// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+// FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //===============================================================================================//
 #include "ReflectiveLoader.h"
@@ -32,10 +32,10 @@ HINSTANCE hAppInstance = NULL;
 //===============================================================================================//
 #ifndef __MINGW32__
 #pragma intrinsic(_ReturnAddress)
-#endif 
+#endif
 // This function can not be inlined by the compiler or we will not get the address we expect. Ideally
-// this code will be compiled with the /O2 and /Ob1 switches. Bonus points if we could take advantage of 
-// RIP relative addressing in this instance but I dont believe we can do so with the compiler intrinsics 
+// this code will be compiled with the /O2 and /Ob1 switches. Bonus points if we could take advantage of
+// RIP relative addressing in this instance but I dont believe we can do so with the compiler intrinsics
 // available (and no inline asm available under x64).
 __declspec(noinline) ULONG_PTR caller( VOID ) { return (ULONG_PTR)_ReturnAddress(); }
 //===============================================================================================//
@@ -46,7 +46,7 @@ __declspec(noinline) ULONG_PTR caller( VOID ) { return (ULONG_PTR)_ReturnAddress
 #define OUTPUTDBG(str) do{}while(0)
 #endif
 
-// Note 1: If you want to have your own DllMain, define REFLECTIVEDLLINJECTION_CUSTOM_DLLMAIN,  
+// Note 1: If you want to have your own DllMain, define REFLECTIVEDLLINJECTION_CUSTOM_DLLMAIN,
 //         otherwise the DllMain at the end of this file will be used.
 
 // Note 2: If you are injecting the DLL via LoadRemoteLibraryR, define REFLECTIVEDLLINJECTION_VIA_LOADREMOTELIBRARYR,
@@ -174,7 +174,7 @@ DLLEXPORT ULONG_PTR WINAPI ReflectiveLoader( VOID )
 
 			// get the VA for the array of name pointers
 			uiNameArray = ( uiBaseAddress + ((PIMAGE_EXPORT_DIRECTORY )uiExportDir)->AddressOfNames );
-			
+
 			// get the VA for the array of name ordinals
 			uiNameOrdinals = ( uiBaseAddress + ((PIMAGE_EXPORT_DIRECTORY )uiExportDir)->AddressOfNameOrdinals );
 
@@ -191,7 +191,7 @@ DLLEXPORT ULONG_PTR WINAPI ReflectiveLoader( VOID )
 			{
 				// compute the hash values for this function name
 				dwHashValue = _hash( (char *)( uiBaseAddress + DEREF_32( uiNameArray ) )  );
-				
+
 				// if we have found a function we want we get its virtual address
 				if( dwHashValue == LOADLIBRARYA_HASH
 					|| dwHashValue == GETPROCADDRESS_HASH
@@ -225,7 +225,7 @@ DLLEXPORT ULONG_PTR WINAPI ReflectiveLoader( VOID )
 					else if( dwHashValue == OUTPUTDEBUG_HASH )
 						pOutputDebug = (OUTPUTDEBUG)( uiBaseAddress + DEREF_32( uiAddressArray ) );
 #endif
-			
+
 					// decrement our counter
 					usCounter--;
 				}
@@ -253,7 +253,7 @@ DLLEXPORT ULONG_PTR WINAPI ReflectiveLoader( VOID )
 
 			// get the VA for the array of name pointers
 			uiNameArray = ( uiBaseAddress + ((PIMAGE_EXPORT_DIRECTORY )uiExportDir)->AddressOfNames );
-			
+
 			// get the VA for the array of name ordinals
 			uiNameOrdinals = ( uiBaseAddress + ((PIMAGE_EXPORT_DIRECTORY )uiExportDir)->AddressOfNameOrdinals );
 
@@ -264,7 +264,7 @@ DLLEXPORT ULONG_PTR WINAPI ReflectiveLoader( VOID )
 			{
 				// compute the hash values for this function name
 				dwHashValue = _hash( (char *)( uiBaseAddress + DEREF_32( uiNameArray ) )  );
-				
+
 				// if we have found a function we want we get its virtual address
 				if( dwHashValue == NTFLUSHINSTRUCTIONCACHE_HASH )
 				{
@@ -313,7 +313,7 @@ DLLEXPORT ULONG_PTR WINAPI ReflectiveLoader( VOID )
 	// get the VA of the NT Header for the PE to be loaded
 	uiHeaderValue = uiLibraryAddress + ((PIMAGE_DOS_HEADER)uiLibraryAddress)->e_lfanew;
 
-	// allocate all the memory for the DLL to be loaded into. we can load at any address because we will  
+	// allocate all the memory for the DLL to be loaded into. we can load at any address because we will
 	// relocate the image. Also zeros all memory and marks it as READ, WRITE and EXECUTE to avoid any problems.
 	uiBaseAddress = (ULONG_PTR)pVirtualAlloc( NULL, ((PIMAGE_NT_HEADERS)uiHeaderValue)->OptionalHeader.SizeOfImage, MEM_RESERVE|MEM_COMMIT, PAGE_EXECUTE_READWRITE );
 
@@ -334,7 +334,7 @@ DLLEXPORT ULONG_PTR WINAPI ReflectiveLoader( VOID )
 
 	// uiValueA = the VA of the first section
 	uiValueA = ( (ULONG_PTR)&((PIMAGE_NT_HEADERS)uiHeaderValue)->OptionalHeader + ((PIMAGE_NT_HEADERS)uiHeaderValue)->FileHeader.SizeOfOptionalHeader );
-	
+
 	// itterate through all sections, loading them into memory.
 	uiValueE = ((PIMAGE_NT_HEADERS)uiHeaderValue)->FileHeader.NumberOfSections;
 	while( uiValueE-- )
@@ -359,11 +359,11 @@ DLLEXPORT ULONG_PTR WINAPI ReflectiveLoader( VOID )
 
 	// uiValueB = the address of the import directory
 	uiValueB = (ULONG_PTR)&((PIMAGE_NT_HEADERS)uiHeaderValue)->OptionalHeader.DataDirectory[ IMAGE_DIRECTORY_ENTRY_IMPORT ];
-	
+
 	// we assume there is an import table to process
 	// uiValueC is the first entry in the import table
 	uiValueC = ( uiBaseAddress + ((PIMAGE_DATA_DIRECTORY)uiValueB)->VirtualAddress );
-	
+
 	// iterate through all imports until a null RVA is found (Characteristics is mis-named)
 	while( ((PIMAGE_IMPORT_DESCRIPTOR)uiValueC)->Characteristics )
 	{
@@ -384,7 +384,7 @@ DLLEXPORT ULONG_PTR WINAPI ReflectiveLoader( VOID )
 
 		// uiValueD = VA of the OriginalFirstThunk
 		uiValueD = ( uiBaseAddress + ((PIMAGE_IMPORT_DESCRIPTOR)uiValueC)->OriginalFirstThunk );
-	
+
 		// uiValueA = VA of the IAT (via first thunk not origionalfirstthunk)
 		uiValueA = ( uiBaseAddress + ((PIMAGE_IMPORT_DESCRIPTOR)uiValueC)->FirstThunk );
 
@@ -475,7 +475,7 @@ DLLEXPORT ULONG_PTR WINAPI ReflectiveLoader( VOID )
 #ifdef WIN_ARM
 				// Note: On ARM, the compiler optimization /O2 seems to introduce an off by one issue, possibly a code gen bug. Using /O1 instead avoids this problem.
 				else if( ((PIMAGE_RELOC)uiValueD)->type == IMAGE_REL_BASED_ARM_MOV32T )
-				{	
+				{
 					register DWORD dwInstruction;
 					register DWORD dwAddress;
 					register WORD wImm;
@@ -549,7 +549,10 @@ extern DWORD DLLEXPORT Init( SOCKET socket );
 
 BOOL MetasploitDllAttach( SOCKET socket )
 {
+    // never called, but causes an undefined reference when DelayLoading is not supported by the compiler.
+	#ifndef __MINGW32__
 	Init( socket );
+	#endif
 	return TRUE;
 }
 
@@ -577,8 +580,8 @@ BOOL WINAPI DllMain( HINSTANCE hinstDLL, DWORD dwReason, LPVOID lpReserved )
 {
     BOOL bReturnValue = TRUE;
 
-	switch( dwReason ) 
-    { 
+	switch( dwReason )
+    {
 		case DLL_METASPLOIT_ATTACH:
 			bReturnValue = MetasploitDllAttach( (SOCKET)lpReserved );
 			break;

--- a/dll/src/ReflectiveLoader.h
+++ b/dll/src/ReflectiveLoader.h
@@ -30,7 +30,7 @@
 //===============================================================================================//
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#include <Winsock2.h>
+#include <winsock2.h>
 #include <intrin.h>
 
 #include "ReflectiveDLLInjection.h"

--- a/inject/src/GetProcAddressR.c
+++ b/inject/src/GetProcAddressR.c
@@ -26,6 +26,12 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //===============================================================================================//
 #include "GetProcAddressR.h"
+
+#ifdef __MINGW32__
+#define __try
+#define __except if
+#endif
+
 //===============================================================================================//
 // We implement a minimal GetProcAddress to avoid using the native kernel32!GetProcAddress which
 // wont be able to resolve exported addresses in reflectivly loaded librarys.

--- a/inject/src/GetProcAddressR.c
+++ b/inject/src/GetProcAddressR.c
@@ -1,35 +1,35 @@
 //===============================================================================================//
 // Copyright (c) 2013, Stephen Fewer of Harmony Security (www.harmonysecurity.com)
 // All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without modification, are permitted 
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted
 // provided that the following conditions are met:
-// 
-//     * Redistributions of source code must retain the above copyright notice, this list of 
+//
+//     * Redistributions of source code must retain the above copyright notice, this list of
 // conditions and the following disclaimer.
-// 
-//     * Redistributions in binary form must reproduce the above copyright notice, this list of 
-// conditions and the following disclaimer in the documentation and/or other materials provided 
+//
+//     * Redistributions in binary form must reproduce the above copyright notice, this list of
+// conditions and the following disclaimer in the documentation and/or other materials provided
 // with the distribution.
-// 
+//
 //     * Neither the name of Harmony Security nor the names of its contributors may be used to
 // endorse or promote products derived from this software without specific prior written permission.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR 
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
 // IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
-// FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR 
-// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+// FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //===============================================================================================//
 #include "GetProcAddressR.h"
 
 #ifdef __MINGW32__
 #define __try
-#define __except if
+#define __except(x) if(0)
 #endif
 
 //===============================================================================================//
@@ -54,7 +54,7 @@ FARPROC WINAPI GetProcAddressR( HANDLE hModule, LPCSTR lpProcName )
 		PIMAGE_NT_HEADERS pNtHeaders             = NULL;
 		PIMAGE_DATA_DIRECTORY pDataDirectory     = NULL;
 		PIMAGE_EXPORT_DIRECTORY pExportDirectory = NULL;
-			
+
 		// get the VA of the modules NT Header
 		pNtHeaders = (PIMAGE_NT_HEADERS)(uiLibraryAddress + ((PIMAGE_DOS_HEADER)uiLibraryAddress)->e_lfanew);
 
@@ -62,13 +62,13 @@ FARPROC WINAPI GetProcAddressR( HANDLE hModule, LPCSTR lpProcName )
 
 		// get the VA of the export directory
 		pExportDirectory = (PIMAGE_EXPORT_DIRECTORY)( uiLibraryAddress + pDataDirectory->VirtualAddress );
-			
+
 		// get the VA for the array of addresses
 		uiAddressArray = ( uiLibraryAddress + pExportDirectory->AddressOfFunctions );
 
 		// get the VA for the array of name pointers
 		uiNameArray = ( uiLibraryAddress + pExportDirectory->AddressOfNames );
-				
+
 		// get the VA for the array of name ordinals
 		uiNameOrdinals = ( uiLibraryAddress + pExportDirectory->AddressOfNameOrdinals );
 
@@ -90,20 +90,20 @@ FARPROC WINAPI GetProcAddressR( HANDLE hModule, LPCSTR lpProcName )
 			while( dwCounter-- )
 			{
 				char * cpExportedFunctionName = (char *)(uiLibraryAddress + DEREF_32( uiNameArray ));
-				
+
 				// test if we have a match...
 				if( strcmp( cpExportedFunctionName, lpProcName ) == 0 )
 				{
 					// use the functions name ordinal as an index into the array of name pointers
 					uiAddressArray += ( DEREF_16( uiNameOrdinals ) * sizeof(DWORD) );
-					
+
 					// calculate the virtual address for the function
 					fpResult = (FARPROC)(uiLibraryAddress + DEREF_32( uiAddressArray ));
-					
+
 					// finish...
 					break;
 				}
-						
+
 				// get the next exported function name
 				uiNameArray += sizeof(DWORD);
 

--- a/inject/src/Inject.c
+++ b/inject/src/Inject.c
@@ -31,7 +31,9 @@
 #include <stdlib.h>
 #include "LoadLibraryR.h"
 
+#ifndef __MINGW32__
 #pragma comment(lib,"Advapi32.lib")
+#endif
 
 #define BREAK_WITH_ERROR( e ) { printf( "[-] %s. Error=%d", e, GetLastError() ); break; }
 

--- a/inject/src/LoadLibraryR.c
+++ b/inject/src/LoadLibraryR.c
@@ -26,6 +26,11 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //===============================================================================================//
 #include "LoadLibraryR.h"
+
+#ifdef __MINGW32__
+#define __try
+#define __except if
+#endif
 //===============================================================================================//
 DWORD Rva2Offset( DWORD dwRva, UINT_PTR uiBaseAddress )
 {    

--- a/inject/src/LoadLibraryR.c
+++ b/inject/src/LoadLibraryR.c
@@ -1,43 +1,43 @@
 //===============================================================================================//
 // Copyright (c) 2013, Stephen Fewer of Harmony Security (www.harmonysecurity.com)
 // All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without modification, are permitted 
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted
 // provided that the following conditions are met:
-// 
-//     * Redistributions of source code must retain the above copyright notice, this list of 
+//
+//     * Redistributions of source code must retain the above copyright notice, this list of
 // conditions and the following disclaimer.
-// 
-//     * Redistributions in binary form must reproduce the above copyright notice, this list of 
-// conditions and the following disclaimer in the documentation and/or other materials provided 
+//
+//     * Redistributions in binary form must reproduce the above copyright notice, this list of
+// conditions and the following disclaimer in the documentation and/or other materials provided
 // with the distribution.
-// 
+//
 //     * Neither the name of Harmony Security nor the names of its contributors may be used to
 // endorse or promote products derived from this software without specific prior written permission.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR 
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
 // IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
-// FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR 
-// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+// FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //===============================================================================================//
 #include "LoadLibraryR.h"
 
 #ifdef __MINGW32__
 #define __try
-#define __except if
+#define __except(x) if(0)
 #endif
 //===============================================================================================//
 DWORD Rva2Offset( DWORD dwRva, UINT_PTR uiBaseAddress )
-{    
+{
 	WORD wIndex                          = 0;
 	PIMAGE_SECTION_HEADER pSectionHeader = NULL;
 	PIMAGE_NT_HEADERS pNtHeaders         = NULL;
-	
+
 	pNtHeaders = (PIMAGE_NT_HEADERS)(uiBaseAddress + ((PIMAGE_DOS_HEADER)uiBaseAddress)->e_lfanew);
 
 	pSectionHeader = (PIMAGE_SECTION_HEADER)((UINT_PTR)(&pNtHeaders->OptionalHeader) + pNtHeaders->FileHeader.SizeOfOptionalHeader);
@@ -46,11 +46,11 @@ DWORD Rva2Offset( DWORD dwRva, UINT_PTR uiBaseAddress )
         return dwRva;
 
     for( wIndex=0 ; wIndex < pNtHeaders->FileHeader.NumberOfSections ; wIndex++ )
-    {   
-        if( dwRva >= pSectionHeader[wIndex].VirtualAddress && dwRva < (pSectionHeader[wIndex].VirtualAddress + pSectionHeader[wIndex].SizeOfRawData) )           
+    {
+        if( dwRva >= pSectionHeader[wIndex].VirtualAddress && dwRva < (pSectionHeader[wIndex].VirtualAddress + pSectionHeader[wIndex].SizeOfRawData) )
            return ( dwRva - pSectionHeader[wIndex].VirtualAddress + pSectionHeader[wIndex].PointerToRawData );
     }
-    
+
     return 0;
 }
 //===============================================================================================//
@@ -74,7 +74,7 @@ DWORD GetReflectiveLoaderOffset( VOID * lpReflectiveDllBuffer )
 	// get the File Offset of the modules NT Header
 	uiExportDir = uiBaseAddress + ((PIMAGE_DOS_HEADER)uiBaseAddress)->e_lfanew;
 
-	// currenlty we can only process a PE file which is the same type as the one this fuction has  
+	// currenlty we can only process a PE file which is the same type as the one this fuction has
 	// been compiled as, due to various offset in the PE structures being defined at compile time.
 	if( ((PIMAGE_NT_HEADERS)uiExportDir)->OptionalHeader.Magic == 0x010B ) // PE32
 	{
@@ -104,7 +104,7 @@ DWORD GetReflectiveLoaderOffset( VOID * lpReflectiveDllBuffer )
 	uiAddressArray = uiBaseAddress + Rva2Offset( ((PIMAGE_EXPORT_DIRECTORY )uiExportDir)->AddressOfFunctions, uiBaseAddress );
 
 	// get the File Offset for the array of name ordinals
-	uiNameOrdinals = uiBaseAddress + Rva2Offset( ((PIMAGE_EXPORT_DIRECTORY )uiExportDir)->AddressOfNameOrdinals, uiBaseAddress );	
+	uiNameOrdinals = uiBaseAddress + Rva2Offset( ((PIMAGE_EXPORT_DIRECTORY )uiExportDir)->AddressOfNameOrdinals, uiBaseAddress );
 
 	// get a counter for the number of exported functions...
 	dwCounter = ((PIMAGE_EXPORT_DIRECTORY )uiExportDir)->NumberOfNames;
@@ -117,8 +117,8 @@ DWORD GetReflectiveLoaderOffset( VOID * lpReflectiveDllBuffer )
 		if( strstr( cpExportedFunctionName, "ReflectiveLoader" ) != NULL )
 		{
 			// get the File Offset for the array of addresses
-			uiAddressArray = uiBaseAddress + Rva2Offset( ((PIMAGE_EXPORT_DIRECTORY )uiExportDir)->AddressOfFunctions, uiBaseAddress );	
-	
+			uiAddressArray = uiBaseAddress + Rva2Offset( ((PIMAGE_EXPORT_DIRECTORY )uiExportDir)->AddressOfFunctions, uiBaseAddress );
+
 			// use the functions name ordinal as an index into the array of name pointers
 			uiAddressArray += ( DEREF_16( uiNameOrdinals ) * sizeof(DWORD) );
 
@@ -166,7 +166,7 @@ HMODULE WINAPI LoadLibraryR( LPVOID lpBuffer, DWORD dwLength )
 				{
 					// call the loaded librarys DllMain to get its HMODULE
 					// Dont call DLL_METASPLOIT_ATTACH/DLL_METASPLOIT_DETACH as that is for payloads only.
-					if( !pDllMain( NULL, DLL_QUERY_HMODULE, &hResult ) )	
+					if( !pDllMain( NULL, DLL_QUERY_HMODULE, &hResult ) )
 						hResult = NULL;
 				}
 				// revert to the previous protection flags...
@@ -183,12 +183,12 @@ HMODULE WINAPI LoadLibraryR( LPVOID lpBuffer, DWORD dwLength )
 }
 //===============================================================================================//
 // Loads a PE image from memory into the address space of a host process via the image's exported ReflectiveLoader function
-// Note: You must compile whatever you are injecting with REFLECTIVEDLLINJECTION_VIA_LOADREMOTELIBRARYR 
+// Note: You must compile whatever you are injecting with REFLECTIVEDLLINJECTION_VIA_LOADREMOTELIBRARYR
 //       defined in order to use the correct RDI prototypes.
-// Note: The hProcess handle must have these access rights: PROCESS_CREATE_THREAD | PROCESS_QUERY_INFORMATION | 
+// Note: The hProcess handle must have these access rights: PROCESS_CREATE_THREAD | PROCESS_QUERY_INFORMATION |
 //       PROCESS_VM_OPERATION | PROCESS_VM_WRITE | PROCESS_VM_READ
 // Note: If you are passing in an lpParameter value, if it is a pointer, remember it is for a different address space.
-// Note: This function currently cant inject accross architectures, but only to architectures which are the 
+// Note: This function currently cant inject accross architectures, but only to architectures which are the
 //       same as the arch this function is compiled as, e.g. x86->x86 and x64->x64 but not x64->x86 or x86->x64.
 HANDLE WINAPI LoadRemoteLibraryR( HANDLE hProcess, LPVOID lpBuffer, DWORD dwLength, LPVOID lpParameter )
 {
@@ -211,7 +211,7 @@ HANDLE WINAPI LoadRemoteLibraryR( HANDLE hProcess, LPVOID lpBuffer, DWORD dwLeng
 				break;
 
 			// alloc memory (RWX) in the host process for the image...
-			lpRemoteLibraryBuffer = VirtualAllocEx( hProcess, NULL, dwLength, MEM_RESERVE|MEM_COMMIT, PAGE_EXECUTE_READWRITE ); 
+			lpRemoteLibraryBuffer = VirtualAllocEx( hProcess, NULL, dwLength, MEM_RESERVE|MEM_COMMIT, PAGE_EXECUTE_READWRITE );
 			if( !lpRemoteLibraryBuffer )
 				break;
 


### PR DESCRIPTION
This pr brings minor changes so that ReflectiveDLLInjection can be built with other compilers than MSVC. 

# instructions

## build dependencies

### Archlinux

clang
aur/mingw-w64-winpthreads-bin
aur/mingw-w64-headers-bin

### Ubuntu

\# apt-get remove mingw*
wget https://launchpad.net/ubuntu/+archive/primary/+files/mingw-w64-common_6.0.0-3_all.deb
wget https://launchpad.net/ubuntu/+archive/primary/+files/mingw-w64-x86-64-dev_6.0.0-3_all.deb
dpkg -i mingw-w64-common_6.0.0-3_all.deb
dpkg -i mingw-w64-x86-64-dev_6.0.0-3_all.deb

## build instructions

git clone https://github.com/plowsec/metasploit-payloads
cd metasploit-payloads
git submodule update --init --recursive
cd c/meterpreter/source/ReflectiveDLLInjection
git fetch origin pull/7/head:pr/7 && git checkout pr/7

### build ReflectiveDLLInjection
cd ../../workspace/ReflectiveDLLInjection
mkdir CMakeBuild && cd CMakeBuild
cmake .. && make