### PR TITLE
Change the default DllMain implementation

### DIFF
--- a/dll/src/ReflectiveLoader.c
+++ b/dll/src/ReflectiveLoader.c
@@ -546,50 +546,12 @@ DLLEXPORT ULONG_PTR WINAPI ReflectiveLoader( VOID )
 //===============================================================================================//
 #ifndef REFLECTIVEDLLINJECTION_CUSTOM_DLLMAIN
 
-// you must implement this function...
-extern DWORD DLLEXPORT Init( SOCKET socket );
-
-BOOL MetasploitDllAttach( SOCKET socket )
-{
-    // never called, but causes an undefined reference when DelayLoading is not supported by the compiler.
-	#ifndef __MINGW32__
-	Init( socket );
-	#endif
-	return TRUE;
-}
-
-BOOL MetasploitDllDetach( DWORD dwExitFunc )
-{
-	switch( dwExitFunc )
-	{
-		case EXITFUNC_SEH:
-			SetUnhandledExceptionFilter( NULL );
-			break;
-		case EXITFUNC_THREAD:
-			ExitThread( 0 );
-			break;
-		case EXITFUNC_PROCESS:
-			ExitProcess( 0 );
-			break;
-		default:
-			break;
-	}
-
-	return TRUE;
-}
-
 BOOL WINAPI DllMain( HINSTANCE hinstDLL, DWORD dwReason, LPVOID lpReserved )
 {
     BOOL bReturnValue = TRUE;
 
 	switch( dwReason )
     {
-		case DLL_METASPLOIT_ATTACH:
-			bReturnValue = MetasploitDllAttach( (SOCKET)lpReserved );
-			break;
-		case DLL_METASPLOIT_DETACH:
-			bReturnValue = MetasploitDllDetach( (DWORD)((DWORD_PTR)lpReserved & 0xFFFFFFFF) );
-			break;
 		case DLL_QUERY_HMODULE:
 			if( lpReserved != NULL )
 				*(HMODULE *)lpReserved = hAppInstance;


### PR DESCRIPTION
While refactoring the relationship between Metsrv and the extensions, I removed the "reference" to Metsrv from all the extension projects. An interesting error appeared that I thought was very strong. The error said that the "Init()" function was missing, which is odd because the _only_ DLL that uses RDI that requires the Init() function is Metsrv. None of the extensions (or any other RDI DLLs in the exploits) should have this at all.

This code change modifies the default behaviour such that all RDI DLLs get a simple DllMain with standard behaviour. Given that Metsrv is the exception, not the rule, this definitely makes the most sense. The functionality required by Metsrv now lives only in Metsrv.