### PR TITLE
Change RDI so that the loader function can be specified by name or ordinal

### DIFF
--- a/dll/src/ReflectiveLoader.c
+++ b/dll/src/ReflectiveLoader.c
@@ -52,11 +52,18 @@ __declspec(noinline) ULONG_PTR caller( VOID ) { return (ULONG_PTR)_ReturnAddress
 // Note 2: If you are injecting the DLL via LoadRemoteLibraryR, define REFLECTIVEDLLINJECTION_VIA_LOADREMOTELIBRARYR,
 //         otherwise it is assumed you are calling the ReflectiveLoader via a stub.
 
+
+#ifdef RDIDLL_NOEXPORT
+#define RDIDLLEXPORT
+#else
+#define RDIDLLEXPORT DLLEXPORT
+#endif
+
 // This is our position independent reflective DLL loader/injector
 #ifdef REFLECTIVEDLLINJECTION_VIA_LOADREMOTELIBRARYR
-DLLEXPORT ULONG_PTR WINAPI ReflectiveLoader( LPVOID lpParameter )
+RDIDLLEXPORT ULONG_PTR WINAPI ReflectiveLoader( LPVOID lpParameter )
 #else
-DLLEXPORT ULONG_PTR WINAPI ReflectiveLoader( VOID )
+RDIDLLEXPORT ULONG_PTR WINAPI ReflectiveLoader( VOID )
 #endif
 {
 	// the functions we need

--- a/inject/src/GetProcAddressR.c
+++ b/inject/src/GetProcAddressR.c
@@ -73,7 +73,7 @@ FARPROC WINAPI GetProcAddressR( HANDLE hModule, LPCSTR lpProcName )
 		uiNameOrdinals = ( uiLibraryAddress + pExportDirectory->AddressOfNameOrdinals );
 
 		// test if we are importing by name or by ordinal...
-		if( ((DWORD)lpProcName & 0xFFFF0000 ) == 0x00000000 )
+		if( (((DWORD_PTR)lpProcName) >> 16) == 0 )
 		{
 			// import by ordinal...
 

--- a/inject/src/Inject.c
+++ b/inject/src/Inject.c
@@ -102,7 +102,8 @@ int main( int argc, char * argv[] )
 		if( !hProcess )
 			BREAK_WITH_ERROR( "Failed to open the target process" );
 
-		hModule = LoadRemoteLibraryR( hProcess, lpBuffer, dwLength, NULL );
+		hModule = LoadRemoteLibraryR( hProcess, lpBuffer, dwLength, "ReflectiveLoader", NULL );
+		//hModule = LoadRemoteLibraryR( hProcess, lpBuffer, dwLength, MAKEINTRESOURCE(1), NULL );
 		if( !hModule )
 			BREAK_WITH_ERROR( "Failed to inject the DLL" );
 

--- a/inject/src/LoadLibraryR.c
+++ b/inject/src/LoadLibraryR.c
@@ -119,7 +119,7 @@ DWORD GetReflectiveLoaderOffset(VOID* lpReflectiveDllBuffer, LPCSTR cpReflective
 	uiNameOrdinals = uiBaseAddress + Rva2Offset(((PIMAGE_EXPORT_DIRECTORY)uiExportDir)->AddressOfNameOrdinals, uiBaseAddress, is64);
 
 	// test if we are importing by name or by ordinal...
-	if (((DWORD)cpReflectiveLoaderName & 0xFFFF0000) == 0x00000000)
+	if ((((DWORD_PTR)cpReflectiveLoaderName) >> 16) == 0)
 	{
 		// import by ordinal...
 

--- a/inject/src/LoadLibraryR.h
+++ b/inject/src/LoadLibraryR.h
@@ -30,11 +30,9 @@
 //===============================================================================================//
 #include "ReflectiveDLLInjection.h"
 
-DWORD GetReflectiveLoaderOffset( VOID * lpReflectiveDllBuffer );
-
-HMODULE WINAPI LoadLibraryR( LPVOID lpBuffer, DWORD dwLength );
-
-HANDLE WINAPI LoadRemoteLibraryR( HANDLE hProcess, LPVOID lpBuffer, DWORD dwLength, LPVOID lpParameter );
+DWORD GetReflectiveLoaderOffset(VOID* lpReflectiveDllBuffer, LPCSTR cpReflectiveLoaderName);
+HMODULE WINAPI LoadLibraryR(LPVOID lpBuffer, DWORD dwLength, LPCSTR cpReflectiveLoaderName);
+HANDLE WINAPI LoadRemoteLibraryR(HANDLE hProcess, LPVOID lpBuffer, DWORD dwLength, LPCSTR cpReflectiveLoaderName, LPVOID lpParameter);
 
 //===============================================================================================//
 #endif


### PR DESCRIPTION
With the goal of removing more and more recognisable stuff from the DLLs, I've modified the code to allow the user to specify the name or ordinal of the ReflectiveLoader.

This means that:

1) The loader can be exported via a DEF using a different name or ordinal
2) The loader can still load that custom DLL
3) We can remove all evidence of `ReflectiveLoader` from the DLL images we produce, and load functions based on ordinals

Clearly this breaks back compat, so it might need to be rolled into all the other things that we've done.

This relates to:
* [Meterpreter PR](https://github.com/rapid7/metasploit-payloads/pull/401)
* [Metasploit PR](https://github.com/rapid7/metasploit-framework/pull/13476)