### PR TITLE
Fix VirtualProtectEx failure with ERROR_NOACCESS (998)

### DIFF
--- a/inject/src/LoadLibraryR.c
+++ b/inject/src/LoadLibraryR.c
@@ -222,6 +222,7 @@ HANDLE WINAPI LoadRemoteLibraryR( HANDLE hProcess, LPVOID lpBuffer, DWORD dwLeng
 	HANDLE hThread                            = NULL;
 	DWORD dwReflectiveLoaderOffset            = 0;
 	DWORD dwThreadId                          = 0;
+	DWORD dwOldProt;
 
 	__try
 	{
@@ -245,7 +246,7 @@ HANDLE WINAPI LoadRemoteLibraryR( HANDLE hProcess, LPVOID lpBuffer, DWORD dwLeng
 				break;
 
 			// change the permissions to (RX) to bypass W^X protections
-			if (!VirtualProtectEx(hProcess, lpRemoteLibraryBuffer, dwLength, PAGE_EXECUTE_READ, NULL))
+			if (!VirtualProtectEx(hProcess, lpRemoteLibraryBuffer, dwLength, PAGE_EXECUTE_READ, &dwOldProt))
 				break;
 
 			// add the offset to ReflectiveLoader() to the remote library address...


### PR DESCRIPTION
As official MSDN documentation says, the last parameter CANNOT be NULL, otherwise:
  `If this parameter is NULL or does not point to a valid variable, the function fails.`