### PR TITLE
Fix Direct Syscalls trampoline detection for Win10, Win8, Win8.1 (x86)

### DIFF
--- a/dll/src/DirectSyscall.c
+++ b/dll/src/DirectSyscall.c
@@ -43,122 +43,40 @@ NTSTATUS rdiNtLockVirtualMemory(Syscall* pSyscall, HANDLE hProcess, PVOID* pBase
 
 
 //
-// Extract the syscall number and the address of the instruction sequence "syscall/retn"
+// Extract the system call trampoline address in ntdll.dll
 //
-BOOL ExtractSysCallData(PVOID pStub, Syscall *pSyscall) {
-	INT8 cIdxStub = 0, cOffsetStub = 0;
-	PBYTE pbCurrentByte = NULL;
-
+BOOL ExtractTrampolineAddress(PVOID pStub, Syscall *pSyscall) {
 	if (pStub == NULL || pSyscall == NULL)
 		return FALSE;
 
-	for (cIdxStub = 0; cIdxStub < SYS_STUB_SIZE; cIdxStub++) {
-		pbCurrentByte = (PBYTE)pStub + cIdxStub;
+	// If the stub starts with the right bytes, check the syscall number to make sure it is the expected stub.
+	// Ignore this check if it is hooked (it starts with byte `0xe9`) and assume this is the expected stub.
+	// Finally, return the address right after the syscall number or the hook.
 
-		if (*pbCurrentByte == 0xc3) // Too far
-			return FALSE;
 #ifdef _WIN64
-		// On x64 Windows, the function starts like this:
-		// 4C 8B D1          mov r10, rcx
-		// B8 96 00 00 00    mov eax, 96h   ; syscall number
-		//
-		// If it is hooked a `jmp <offset>` will be found instead
-		// E9 4B 03 00 80    jmp 7FFE6BCA0000
-		// folowed by the 3 remaining bytes from the original code:
-		// 00 00 00
-		if (*(PUINT32)pbCurrentByte == 0xb8d18b4c || *pbCurrentByte == 0xe9) {
-
-			// Then on Windows 10/11 (x64):
-			// F6 04 25 08 03 FE 7F 01    test    byte ptr ds:7FFE0308h, 1
-			// 75 03                      jnz     short loc_1800A4E65
-			// 0F 05                      syscall            ; XOR'ing these bytes to obfuscate them when comparing below
-			// C3                         retn
-			if (*(PUINT64)(pbCurrentByte + 8) == 0x017ffe03082504f6 && (*(PUINT32)(pbCurrentByte + 16) ^ 0x01010101) == 0x040e0274 && *(pbCurrentByte + 20) == 0xc3) {
-				cOffsetStub = cIdxStub + 18;
-				break;
-			}
-
-			// On Windows 7 SP1 (x64), Windows Server 2012 (x64), Windows Vista (x64) and Windows XP (x64):
-			// 0F 05                        syscall           ; XOR'ing these bytes to obfuscate them when comparing below
-			// C3                           retn
-			if ((*(PUINT16)(pbCurrentByte + 8) ^ 0x0101) == 0x040e && *(pbCurrentByte + 10) == 0xc3) {
-				cOffsetStub = cIdxStub + 8;
-				break;
-			}
-		}
-#else
-		// On x86 ntdll, it starts like this:
-		// B8 F1 00 00 00               mov     eax, 0F1h      ; syscall number
-		//
-		// If it is hooked a `jmp <offset>` will be found instead
-		// E9 99 00 00 00               jmp     775ECAA1
-		if (*pbCurrentByte == 0xb8 || *pbCurrentByte == 0xe9) {
-			if (
-
-				// Then, on Windows 10/11 WoW64 (x64):
-				// BA 00 8F 31 4B               mov     edx, offset _Wow64SystemServiceCall@0 ; we cannot match on the offset since it changes
-				// FF D2                        call    edx            ; Wow64SystemServiceCall()
-				// C2 10 00                     retn    10h ; this can also be "C3   retn"
-				*(pbCurrentByte + 5) == 0xba && *(PUINT16)(pbCurrentByte + 10) == 0xd2ff && (*(pbCurrentByte + 12) == 0xc2 || *(pbCurrentByte + 12) == 0xc3) ||
-
-				// Windows 7 SP1 (x86), Windows Vista (x86) and Windows XP (x86):
-				// BA 00 03 FE 7F               mov     edx, 7FFE0300h
-				// FF 12                        call    dword ptr[edx]
-				// C2 18 00		                retn    18h ; this can also be "C3   retn"
-				*(pbCurrentByte + 5) == 0xba && *(PUINT16)(pbCurrentByte + 10) == 0x12ff && (*(pbCurrentByte + 12) == 0xc2 || *(pbCurrentByte + 12) == 0xc3) ||
-
-				// On Windows 7 SP1 WoW64 (x64), it has two variants. So, let's ignore the first instruction and match the remaining bytes.
-				// Variant #1:
-				// 33 C9                        xor     ecx, ecx
-				// 8D 54 24 04                  lea     edx, [esp+arg_0]
-				// 64 FF 15 C0 00 00 00         call    large dword ptr fs:0C0h
-				// 83 C4 04                     add     esp, 4
-				// C2 0C 00                     retn    0Ch ; this can also be "C3   retn"
-				*(PUINT64)(pbCurrentByte + 7) == 0xc015ff640424548d && *(PUINT32)(pbCurrentByte + 15) == 0x83000000 && *(PUINT16)(pbCurrentByte + 19) == 0x04c4 && (*(pbCurrentByte + 21) == 0xc2 || *(pbCurrentByte + 21) == 0xc3) ||
-
-				// Variant #2:
-				// B9 0C 00 00 00               mov     ecx, 0Ch
-				// 8D 54 24 04                  lea     edx, [esp+arg_0]
-				// 64 FF 15 C0 00 00 00         call    large dword ptr fs:0C0h
-				// 83 C4 04                     add     esp, 4
-				// C2 0C 00                     retn    0Ch ; this can also be "C3   retn"
-				*(PUINT64)(pbCurrentByte + 10) == 0xc015ff640424548d && *(PUINT32)(pbCurrentByte + 18) == 0x83000000 && *(PUINT16)(pbCurrentByte + 22) == 0x04c4 && (*(pbCurrentByte + 24) == 0xc2 || *(pbCurrentByte + 24) == 0xc3) ||
-
-				// On Windows Server 2012 WoW64 (x64)
-				// 64 FF 15 C0 00 00 00         call    large dword ptr fs:0C0h
-				// C2 0C 00                     retn    0Ch ; this can also be "C3   retn"
-				(*(PUINT64)(pbCurrentByte + 5) == 0xc2000000c015ff64 || *(PUINT64)(pbCurrentByte + 5) == 0xc3000000c015ff64) ||
-
-				// On Windows 10/11 WoW64 (x64) for one function (ZwQueryInformationProcess):
-				// E8 00 00 00 00               call    $+5
-				// 5A                           pop     edx
-				// 80 7A 14 4B                  cmp     byte ptr[edx + 14h], 4Bh; 'K'
-				// 75 0E                        jnz     short loc_4B2F4CDF
-				// 64 FF 15 C0 00 00 00         call    large dword ptr fs : 0C0h
-				// C2 14 00                     retn    14h
-				*(PUINT64)(pbCurrentByte + 17) == 0xc2000000c015ff64 ||
-
-				// On Windows 10, Windows 8, Windows 8.1 and Windows 8.1 SP1 (x86):
-				// E8 03 00 00 00               call    sub_6A290C2D
-				// C2 18 00                     retn    18h
-				// 8B D4                        mov     edx, esp
-				// 0F 34                        sysenter    ; XOR'ing these bytes to obfuscate them when comparing below
-				// C3                           retn
-				*(PUINT32)(pbCurrentByte + 5) == 0x000003e8 && *(PUINT16)(pbCurrentByte + 9) == 0xc200 && (*(PUINT32)(pbCurrentByte + 13) ^ 0x01010101) == 0x350ed58a && *(pbCurrentByte + 17) == 0xc3
-
-				) {
-				cOffsetStub = cIdxStub + 5;
-				break;
-			}
-		}
-#endif
-
-	}
-
-	if (cOffsetStub > 0) {
-		pSyscall->pStub = (LPVOID)((PBYTE)pStub + cOffsetStub);
+	// On x64 Windows, the function starts like this:
+	// 4C 8B D1          mov r10, rcx
+	// B8 96 00 00 00    mov eax, 96h   ; syscall number
+	//
+	// If it is hooked a `jmp <offset>` will be found instead
+	// E9 4B 03 00 80    jmp 7FFE6BCA0000
+	// folowed by the 3 remaining bytes from the original code:
+	// 00 00 00
+	if (*(PUINT32)pStub == 0xb8d18b4c && *(PUINT16)((PBYTE)pStub + 4) == pSyscall->dwSyscallNr || *(PBYTE)pStub == 0xe9) {
+		pSyscall->pStub = (LPVOID)((PBYTE)pStub + 8);
 		return TRUE;
 	}
+#else
+	// On x86 ntdll, it starts like this:
+	// B8 F1 00 00 00    mov     eax, 0F1h   ; syscall number
+	//
+	// If it is hooked a `jmp <offset>` will be found instead
+	// E9 99 00 00 00    jmp     775ECAA1
+	if (*(PBYTE)pStub == 0xb8 && *(PUINT16)((PBYTE)pStub + 1) == pSyscall->dwSyscallNr || *(PBYTE)pStub == 0xe9) {
+		pSyscall->pStub = (LPVOID)((PBYTE)pStub + 5);
+		return TRUE;
+	}
+#endif
 
 	return FALSE;
 }
@@ -231,10 +149,9 @@ BOOL getSyscalls(PVOID pNtdllBase, Syscall* Syscalls[], DWORD dwSyscallSize) {
 	for (dwIdxSyscall = 0; dwIdxSyscall < dwSyscallSize; ++dwIdxSyscall) {
 		for (i = 0; i < SyscallList.dwCount; ++i) {
 			if (SyscallList.Entries[i].dwCryptedHash == Syscalls[dwIdxSyscall]->dwCryptedHash) {
-
-				if (!ExtractSysCallData(SyscallList.Entries[i].pAddress, Syscalls[dwIdxSyscall]))
-					return FALSE;
 				Syscalls[dwIdxSyscall]->dwSyscallNr = i;
+				if (!ExtractTrampolineAddress(SyscallList.Entries[i].pAddress, Syscalls[dwIdxSyscall]))
+					return FALSE;
 				break;
 			}
 		}


### PR DESCRIPTION
This adds the missing trampoline detection for the x86 version of Windows 10, 8, 8.1 and 8.1 SP1. This also adds some basic obfuscation to avoid having `syscall` and `sysenter` instruction opcodes in clear in the binary.