### PR TITLE
Add ARM64 Support and Modernize Syscall Framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ inject/inject.vcxproj.user
 *.opensdf
 *.suo
 bin/
+/.vs/rdi

--- a/dll/reflective_dll.vcxproj
+++ b/dll/reflective_dll.vcxproj
@@ -5,6 +5,10 @@
       <Configuration>Debug</Configuration>
       <Platform>ARM</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
@@ -16,6 +20,10 @@
     <ProjectConfiguration Include="Release|ARM">
       <Configuration>Release</Configuration>
       <Platform>ARM</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
     </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
@@ -35,35 +43,46 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
@@ -85,7 +104,13 @@
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
@@ -108,6 +133,12 @@
     <LinkIncremental>true</LinkIncremental>
     <TargetName>$(ProjectName).$(Platform)</TargetName>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <LinkIncremental>true</LinkIncremental>
+    <TargetName>$(ProjectName).$(Platform)</TargetName>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
     <IntDir>$(Configuration)\</IntDir>
@@ -119,6 +150,12 @@
     <TargetName>$(ProjectName).$(Platform)</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <LinkIncremental>false</LinkIncremental>
+    <TargetName>$(ProjectName).$(Platform)</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\</IntDir>
     <LinkIncremental>false</LinkIncremental>
@@ -196,6 +233,30 @@
       </ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <Midl />
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;REFLECTIVE_DLL_EXPORTS;_WIN64;REFLECTIVEDLLINJECTION_VIA_LOADREMOTELIBRARYR;REFLECTIVEDLLINJECTION_CUSTOM_DLLMAIN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>false</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>EnableAllWarnings</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalIncludeDirectories>../common</AdditionalIncludeDirectories>
+      <LanguageStandard>Default</LanguageStandard>
+      <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <ModuleDefinitionFile>
+      </ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <Optimization>Custom</Optimization>
@@ -265,7 +326,7 @@
       <TargetEnvironment>X64</TargetEnvironment>
     </Midl>
     <ClCompile>
-      <Optimization>Custom</Optimization>
+      <Optimization>MaxSpeed</Optimization>
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
       <IntrinsicFunctions>false</IntrinsicFunctions>
       <FavorSizeOrSpeed>Size</FavorSizeOrSpeed>
@@ -303,6 +364,47 @@
       </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <Midl />
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
+      <IntrinsicFunctions>false</IntrinsicFunctions>
+      <FavorSizeOrSpeed>Size</FavorSizeOrSpeed>
+      <WholeProgramOptimization>false</WholeProgramOptimization>
+      <PreprocessorDefinitions>_WINDOWS;_USRDLL;REFLECTIVE_DLL_EXPORTS;_WIN64;REFLECTIVEDLLINJECTION_VIA_LOADREMOTELIBRARYR;REFLECTIVEDLLINJECTION_CUSTOM_DLLMAIN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>EnableAllWarnings</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalIncludeDirectories>../common</AdditionalIncludeDirectories>
+      <CompileAs>Default</CompileAs>
+      <LanguageStandard>Default</LanguageStandard>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <OmitFramePointers>true</OmitFramePointers>
+      <StringPooling>true</StringPooling>
+      <AdditionalOptions>/Og %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+    <Link>
+      <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <StackReserveSize>
+      </StackReserveSize>
+      <StackCommitSize>
+      </StackCommitSize>
+      <ModuleDefinitionFile>
+      </ModuleDefinitionFile>
+    </Link>
+    <PostBuildEvent>
+      <Command>
+      </Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="src\DirectSyscall.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
@@ -310,7 +412,9 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="src\ReflectiveDll.c" />
     <ClCompile Include="src\ReflectiveLoader.c" />
@@ -323,26 +427,27 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</ExcludedFromBuild>
     </ClInclude>
     <ClInclude Include="src\ReflectiveLoader.h" />
   </ItemGroup>
-  <ItemGroup>
-    <MASM Include="src\GateTrampoline32.asm">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-      <FileType>Document</FileType>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</ExcludedFromBuild>
-    </MASM>
-    <MASM Include="src\GateTrampoline64.asm">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-      <FileType>Document</FileType>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</ExcludedFromBuild>
-    </MASM>
-  </ItemGroup>
+	<ItemGroup>
+		<!-- Rule for x86: Compiles GateTrampoline32.asm only when Platform is Win32 -->
+		<MASM Include="src\GateTrampoline32.asm" Condition="'$(Platform)'=='Win32'" />
+
+		<!-- Rule for x64: Compiles GateTrampoline64.asm only when Platform is x64 -->
+		<MASM Include="src\GateTrampoline64.asm" Condition="'$(Platform)'=='x64'" />
+
+		<!-- Rule for ARM64: Uses a Custom Build rule only when Platform is ARM64 -->
+		<CustomBuild Include="src\GateTrampolineARM64.asm" Condition="'$(Platform)'=='ARM64'">
+			<Command>armasm64.exe -nologo -o"$(IntDir)%(Filename).obj" "%(FullPath)"</Command>
+			<Outputs>$(IntDir)%(Filename).obj</Outputs>
+			<LinkObjects>true</LinkObjects>
+			<Message>Assembling %(Filename)%(Extension)</Message>
+		</CustomBuild>
+	</ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.targets" />

--- a/dll/reflective_dll.vcxproj.filters
+++ b/dll/reflective_dll.vcxproj.filters
@@ -33,10 +33,7 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
-    <MASM Include="src\GateTrampoline32.asm">
-      <Filter>Source Files</Filter>
-    </MASM>
-    <MASM Include="src\GateTrampoline64.asm">
+    <MASM Include="src\GateTrampolineARM64.asm">
       <Filter>Source Files</Filter>
     </MASM>
   </ItemGroup>

--- a/dll/src/DirectSyscall.c
+++ b/dll/src/DirectSyscall.c
@@ -140,13 +140,13 @@ BOOL getSyscalls(PVOID pNtdllBase, Syscall *Syscalls[], DWORD dwSyscallSize)
 				//   C3              ret
 				// The gadget we jump to is at +8 bytes from the start.
 				Syscalls[dwIdxSyscall]->pStub = (PVOID)((PBYTE)SyscallList.Entries[i].pAddress + 8);
-#else // _M_IX86
-				// On x86, the function starts like this:
+#elif defined(_M_IX86)
+				// On x86, the stub often looks like:
 				//   B8 <num>..      mov eax, <syscall_num>
 				//   BA <ptr>..      mov edx, <syscall_dispatch_ptr>
-				//   FF D2           call edx
-				//   C2 0400         ret 4
-				// In ntdll, the call edx points to the 'syscall' instruction. The gadget is at +5 bytes.
+				//   FF D2           call edx  <-- This call is 5 bytes.
+				// The 'call' instruction itself is used as our gadget. Our trampoline will 'ret'
+				// to this location, effectively executing the call to the syscall dispatcher.
 				Syscalls[dwIdxSyscall]->pStub = (PVOID)((PBYTE)SyscallList.Entries[i].pAddress + 5);
 #endif
 #endif

--- a/dll/src/DirectSyscall.c
+++ b/dll/src/DirectSyscall.c
@@ -1,165 +1,176 @@
 #include "DirectSyscall.h"
 
-// Note that compiler optimizations need to be disabled for SyscallStub() and all the rdi...() API functions
-// to make sure the stack is setup in a way that can be handle by DoSyscall() assembly code.
-#pragma optimize( "g", off )
+#pragma optimize("g", off)
 #ifdef __MINGW32__
 #pragma GCC push_options
-#pragma GCC optimize ("O0")
+#pragma GCC optimize("O0")
 #endif
 
-//
-// Main stub that is called by all the native API functions
-//
-#pragma warning(disable: 4100) // warning C4100: unreferenced formal parameter
-NTSTATUS SyscallStub(Syscall* pSyscall, ...) {
+#pragma warning(disable : 4100) // Unreferenced parameter 'pSyscall' is handled by assembly.
+NTSTATUS SyscallStub(Syscall *pSyscall, ...)
+{
+	// This function acts as a bridge to the assembly trampoline. The first argument,
+	// pSyscall, is passed in the first argument register (rcx/x0/stack), and all
+	// subsequent arguments follow the standard C calling convention.
 	return DoSyscall();
 }
-#pragma warning(default: 4100)
+#pragma warning(default : 4100)
 
-//
-// Native API functions
-//
-NTSTATUS rdiNtAllocateVirtualMemory(Syscall* pSyscall, HANDLE hProcess, PVOID* pBaseAddress, ULONG_PTR pZeroBits, PSIZE_T pRegionSize, ULONG ulAllocationType, ULONG ulProtect) {
+NTSTATUS rdiNtAllocateVirtualMemory(Syscall *pSyscall, HANDLE hProcess, PVOID *pBaseAddress, ULONG_PTR pZeroBits, PSIZE_T pRegionSize, ULONG ulAllocationType, ULONG ulProtect)
+{
 	return SyscallStub(pSyscall, hProcess, pBaseAddress, pZeroBits, pRegionSize, ulAllocationType, ulProtect);
 }
-
-NTSTATUS rdiNtProtectVirtualMemory(Syscall* pSyscall, HANDLE hProcess, PVOID* pBaseAddress, PSIZE_T pNumberOfBytesToProtect, ULONG ulNewAccessProtection, PULONG ulOldAccessProtection) {
+NTSTATUS rdiNtProtectVirtualMemory(Syscall *pSyscall, HANDLE hProcess, PVOID *pBaseAddress, PSIZE_T pNumberOfBytesToProtect, ULONG ulNewAccessProtection, PULONG ulOldAccessProtection)
+{
 	return SyscallStub(pSyscall, hProcess, pBaseAddress, pNumberOfBytesToProtect, ulNewAccessProtection, ulOldAccessProtection);
 }
-
-NTSTATUS rdiNtFlushInstructionCache(Syscall* pSyscall, HANDLE hProcess, PVOID* pBaseAddress, SIZE_T FlushSize) {
+NTSTATUS rdiNtFlushInstructionCache(Syscall *pSyscall, HANDLE hProcess, PVOID *pBaseAddress, SIZE_T FlushSize)
+{
 	return SyscallStub(pSyscall, hProcess, pBaseAddress, FlushSize);
 }
-
-NTSTATUS rdiNtLockVirtualMemory(Syscall* pSyscall, HANDLE hProcess, PVOID* pBaseAddress, PSIZE_T NumberOfBytesToLock, ULONG MapType) {
+NTSTATUS rdiNtLockVirtualMemory(Syscall *pSyscall, HANDLE hProcess, PVOID *pBaseAddress, PSIZE_T NumberOfBytesToLock, ULONG MapType)
+{
 	return SyscallStub(pSyscall, hProcess, pBaseAddress, NumberOfBytesToLock, MapType);
 }
 
 #ifdef __MINGW32__
 #pragma GCC pop_options
 #endif
-#pragma optimize( "g", on )
+#pragma optimize("g", on)
 
+// Scans a region of memory for a specific byte pattern (gadget).
+// This is used on ARM64 to find a generic syscall execution gadget.
+static PVOID FindGadget(PBYTE pCodeBase, ULONG ulCodeSize, const PBYTE pGadgetSignature, ULONG ulGadgetSize)
+{
+	if (!pCodeBase || ulCodeSize == 0 || !pGadgetSignature || ulGadgetSize == 0)
+		return NULL;
 
-//
-// Extract the system call trampoline address in ntdll.dll
-//
-BOOL ExtractTrampolineAddress(PVOID pStub, Syscall *pSyscall) {
-	if (pStub == NULL || pSyscall == NULL)
-		return FALSE;
-
-	// If the stub starts with the right bytes, check the syscall number to make sure it is the expected stub.
-	// Ignore this check if it is hooked (it starts with byte `0xe9`) and assume this is the expected stub.
-	// Finally, return the address right after the syscall number or the hook.
-
-#ifdef _WIN64
-	// On x64 Windows, the function starts like this:
-	// 4C 8B D1          mov r10, rcx
-	// B8 96 00 00 00    mov eax, 96h   ; syscall number
-	//
-	// If it is hooked a `jmp <offset>` will be found instead
-	// E9 4B 03 00 80    jmp 7FFE6BCA0000
-	// folowed by the 3 remaining bytes from the original code:
-	// 00 00 00
-	if (*(PUINT32)pStub == 0xb8d18b4c && *(PUINT16)((PBYTE)pStub + 4) == pSyscall->dwSyscallNr || *(PBYTE)pStub == 0xe9) {
-		pSyscall->pStub = (LPVOID)((PBYTE)pStub + 8);
-		return TRUE;
+	for (ULONG i = 0; i <= ulCodeSize - ulGadgetSize; ++i)
+	{
+		BOOL bFound = TRUE;
+		for (ULONG j = 0; j < ulGadgetSize; ++j)
+		{
+			if (pCodeBase[i + j] != pGadgetSignature[j])
+			{
+				bFound = FALSE;
+				break;
+			}
+		}
+		if (bFound)
+		{
+			return (PVOID)(pCodeBase + i);
+		}
 	}
-#else
-	// On x86 ntdll, it starts like this:
-	// B8 F1 00 00 00    mov     eax, 0F1h   ; syscall number
-	//
-	// If it is hooked a `jmp <offset>` will be found instead
-	// E9 99 00 00 00    jmp     775ECAA1
-	if (*(PBYTE)pStub == 0xb8 && *(PUINT16)((PBYTE)pStub + 1) == pSyscall->dwSyscallNr || *(PBYTE)pStub == 0xe9) {
-		pSyscall->pStub = (LPVOID)((PBYTE)pStub + 5);
-		return TRUE;
+	return NULL;
+}
+
+//===============================================================================================//
+// GETSYSCALLS
+//
+// This function is the core of the dynamic syscall resolution mechanism. It populates an
+// array of 'Syscall' structures with the necessary information to perform direct syscalls,
+// bypassing user-land API hooks.
+//
+// The technique, known as "Hell's Gate", relies on the observation that the syscall numbers
+// for ntdll's Zw* functions correspond to their memory address order.
+//
+// For ARM64, this technique is modified. The individual Zw* function stubs are inconsistent.
+// Instead, we use the sorting method to get the correct syscall number but find a single,
+// generic "svc #0; ret" gadget within ntdll's code that we can reuse for all syscalls.
+//===============================================================================================//
+BOOL getSyscalls(PVOID pNtdllBase, Syscall *Syscalls[], DWORD dwSyscallSize)
+{
+	PIMAGE_DOS_HEADER pDosHdr = (PIMAGE_DOS_HEADER)pNtdllBase;
+	PIMAGE_NT_HEADERS pNtHdrs = (PIMAGE_NT_HEADERS)((PBYTE)pNtdllBase + pDosHdr->e_lfanew);
+	PIMAGE_EXPORT_DIRECTORY pExportDir = (PIMAGE_EXPORT_DIRECTORY)((PBYTE)pNtdllBase + pNtHdrs->OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_EXPORT].VirtualAddress);
+
+	PDWORD pdwAddrOfFunctions = (PDWORD)((PBYTE)pNtdllBase + pExportDir->AddressOfFunctions);
+	PDWORD pdwAddrOfNames = (PDWORD)((PBYTE)pNtdllBase + pExportDir->AddressOfNames);
+	PWORD pwAddrOfNameOrdinales = (PWORD)((PBYTE)pNtdllBase + pExportDir->AddressOfNameOrdinals);
+
+	PVOID pSyscallGadget = NULL;
+
+#if defined(_M_ARM64)
+	// On ARM64, we hunt for a generic gadget to execute our syscalls. The pattern
+	// "svc #0; ret" is ideal. Its byte signature is { 0x01, 0x00, 0x00, 0xD4, 0xC0, 0x03, 0x5F, 0xD6 }.
+	const BYTE svc_ret_gadget[] = {0x01, 0x00, 0x00, 0xD4, 0xC0, 0x03, 0x5F, 0xD6};
+	pSyscallGadget = FindGadget((PBYTE)pNtdllBase, pNtHdrs->OptionalHeader.SizeOfImage, svc_ret_gadget, sizeof(svc_ret_gadget));
+	if (!pSyscallGadget)
+	{
+		return FALSE; // Cannot proceed without a valid syscall gadget.
 	}
 #endif
 
-	return FALSE;
-}
-
-//
-// Retrieve the syscall data for every functions in Syscalls and UtilitySyscalls arrays of Syscall structures.
-// It goes through ntdll exports and compare the hash of the function names with the hash contained in the structures.
-// For each matching hash, it extract the syscall data and store it in the structure.
-//
-BOOL getSyscalls(PVOID pNtdllBase, Syscall* Syscalls[], DWORD dwSyscallSize) {
-	PIMAGE_DOS_HEADER pDosHdr = NULL;
-	PIMAGE_NT_HEADERS pNtHdrs = NULL;
-	PIMAGE_EXPORT_DIRECTORY pExportDir = NULL;
-	PDWORD pdwAddrOfNames = NULL, pdwAddrOfFunctions = NULL;
-	PWORD pwAddrOfNameOrdinales = NULL;
-	DWORD dwIdxfName = 0, dwIdxSyscall = 0;
 	SYSCALL_LIST SyscallList;
+	SyscallList.dwCount = 0;
 
-	pDosHdr = (PIMAGE_DOS_HEADER)pNtdllBase;
-	pNtHdrs = (PIMAGE_NT_HEADERS)((PBYTE)pNtdllBase + pDosHdr->e_lfanew);
-	pExportDir = (PIMAGE_EXPORT_DIRECTORY)((PBYTE)pNtdllBase + pNtHdrs->OptionalHeader.DataDirectory[0].VirtualAddress);
-
-	pdwAddrOfFunctions = (PDWORD)((PBYTE)pNtdllBase + pExportDir->AddressOfFunctions);
-	pdwAddrOfNames = (PDWORD)((PBYTE)pNtdllBase + pExportDir->AddressOfNames);
-	pwAddrOfNameOrdinales = (PWORD)((PBYTE)pNtdllBase + pExportDir->AddressOfNameOrdinals);
-
-	// Populate SyscallList with unsorted Zw* entries.
-	DWORD i = 0;
-	SYSCALL_ENTRY* Entries = SyscallList.Entries;
-	for (dwIdxfName = 0; dwIdxfName < pExportDir->NumberOfNames; dwIdxfName++) {
+	// STEP 1: Enumerate all functions exported from ntdll.dll that begin with "Zw".
+	// Store their hash and address in a temporary list.
+	for (DWORD dwIdxfName = 0; dwIdxfName < pExportDir->NumberOfNames; dwIdxfName++)
+	{
 		PCHAR FunctionName = (PCHAR)((PBYTE)pNtdllBase + pdwAddrOfNames[dwIdxfName]);
-
-		// Selecting only system call functions starting with 'Zw'
-		if (*(USHORT*)FunctionName == 0x775a)
+		if (*(USHORT *)FunctionName == 0x775a) // "Zw" in little-endian
 		{
-			Entries[i].dwCryptedHash = _hash(FunctionName);
-			Entries[i].pAddress = (PVOID)((PBYTE)pNtdllBase + pdwAddrOfFunctions[pwAddrOfNameOrdinales[dwIdxfName]]);
-
-			if (++i == MAX_SYSCALLS)
+			if (SyscallList.dwCount >= MAX_SYSCALLS)
 				break;
+			SyscallList.Entries[SyscallList.dwCount].dwCryptedHash = _hash(FunctionName);
+			SyscallList.Entries[SyscallList.dwCount].pAddress = (PVOID)((PBYTE)pNtdllBase + pdwAddrOfFunctions[pwAddrOfNameOrdinales[dwIdxfName]]);
+			SyscallList.dwCount++;
 		}
 	}
 
-	// Save total number of system calls found
-	SyscallList.dwCount = i;
-
-	// Sort the list by address in ascending order.
-	for (i = 0; i < SyscallList.dwCount - 1; i++)
+	// STEP 2: Sort the list of Zw* functions by their memory address.
+	// The index of a function in this sorted list is its syscall number.
+	for (DWORD i = 0; i < SyscallList.dwCount - 1; i++)
 	{
 		for (DWORD j = 0; j < SyscallList.dwCount - i - 1; j++)
 		{
-			if (Entries[j].pAddress > Entries[j + 1].pAddress)
+			if (SyscallList.Entries[j].pAddress > SyscallList.Entries[j + 1].pAddress)
 			{
-				// Swap entries.
-				SYSCALL_ENTRY TempEntry;
-
-				TempEntry.dwCryptedHash = Entries[j].dwCryptedHash;
-				TempEntry.pAddress = Entries[j].pAddress;
-
-				Entries[j].dwCryptedHash = Entries[j + 1].dwCryptedHash;
-				Entries[j].pAddress = Entries[j + 1].pAddress;
-
-				Entries[j + 1].dwCryptedHash = TempEntry.dwCryptedHash;
-				Entries[j + 1].pAddress = TempEntry.pAddress;
+				SYSCALL_ENTRY TempEntry = SyscallList.Entries[j];
+				SyscallList.Entries[j] = SyscallList.Entries[j + 1];
+				SyscallList.Entries[j + 1] = TempEntry;
 			}
 		}
 	}
 
-	// Find the syscall numbers and trampolins we need
-	for (dwIdxSyscall = 0; dwIdxSyscall < dwSyscallSize; ++dwIdxSyscall) {
-		for (i = 0; i < SyscallList.dwCount; ++i) {
-			if (SyscallList.Entries[i].dwCryptedHash == Syscalls[dwIdxSyscall]->dwCryptedHash) {
+	// STEP 3: Find the syscalls required by our loader. For each one, store its
+	// syscall number (its index 'i') and the address of the syscall execution stub.
+	for (DWORD dwIdxSyscall = 0; dwIdxSyscall < dwSyscallSize; ++dwIdxSyscall)
+	{
+		BOOL bFound = FALSE;
+		for (DWORD i = 0; i < SyscallList.dwCount; ++i)
+		{
+			if (SyscallList.Entries[i].dwCryptedHash == Syscalls[dwIdxSyscall]->dwCryptedHash)
+			{
 				Syscalls[dwIdxSyscall]->dwSyscallNr = i;
-				if (!ExtractTrampolineAddress(SyscallList.Entries[i].pAddress, Syscalls[dwIdxSyscall]))
-					return FALSE;
+
+#if defined(_M_ARM64)
+				// On ARM64, we use the single, generic gadget we found earlier.
+				Syscalls[dwIdxSyscall]->pStub = pSyscallGadget;
+#else
+// On x86/x64, the syscall gadget is at a predictable offset from the function's start.
+// This offset is where the 'syscall; ret' instructions reside, bypassing any hook.
+#if defined(_M_X64)
+				Syscalls[dwIdxSyscall]->pStub = (PVOID)((PBYTE)SyscallList.Entries[i].pAddress + 8);
+#else // _M_IX86
+				Syscalls[dwIdxSyscall]->pStub = (PVOID)((PBYTE)SyscallList.Entries[i].pAddress + 5);
+#endif
+#endif
+				bFound = TRUE;
 				break;
 			}
 		}
+		if (!bFound)
+		{
+			return FALSE; // A required syscall was not found in ntdll.
+		}
 	}
 
-	// Last check to make sure we have everything we need
-	for (dwIdxSyscall = 0; dwIdxSyscall < dwSyscallSize; ++dwIdxSyscall) {
-		if (Syscalls[dwIdxSyscall]->pStub == NULL)
+	// Final validation to ensure all syscall stubs were successfully resolved.
+	for (DWORD i = 0; i < dwSyscallSize; ++i)
+	{
+		if (Syscalls[i]->pStub == NULL)
 			return FALSE;
 	}
 

--- a/dll/src/GateTrampolineARM64.asm
+++ b/dll/src/GateTrampolineARM64.asm
@@ -1,0 +1,43 @@
+;
+; ARM64 Syscall Trampoline for Reflective DLL Injection
+; Microsoft ARM64 Assembler (armasm64.exe) syntax.
+;
+    AREA    |.text|, CODE, READONLY, ALIGN=3
+    EXPORT  DoSyscall
+
+DoSyscall
+    ; Preserve callee-saved register x19 and the link register x30
+    STP     x19, x30, [sp, #-16]!
+
+    ; The C wrapper called us. x0 holds pSyscall. Save it.
+    MOV     x19, x0
+
+    ; The syscall convention requires arguments in x0-x7. The C wrapper passed
+    ; our target arguments in x1-x7. We shift them left by one register.
+    MOV     x0, x1
+    MOV     x1, x2
+    MOV     x2, x3
+    MOV     x3, x4
+    MOV     x4, x5
+    MOV     x5, x6
+    MOV     x6, x7
+
+    ; Load the syscall number from the Syscall struct into x8
+    LDR     w8, [x19, #8]
+
+    ; Load the address of the syscall gadget from pSyscall->pStub
+    LDR     x10, [x19, #16]
+
+    ; Branch With Link to Register, calling the gadget.
+    BLR     x10
+
+    ; The syscall's return value is now in x0.
+
+    ; Restore the saved registers
+    LDP     x19, x30, [sp], #16
+
+    ; Return to the C caller
+    RET
+
+    ALIGN
+    END

--- a/dll/src/ReflectiveLoader.c
+++ b/dll/src/ReflectiveLoader.c
@@ -455,15 +455,34 @@ RDIDLLEXPORT ULONG_PTR WINAPI ReflectiveLoader(VOID)
 {
 	LOADER_CONTEXT context = {0};
 
-	// Initialize the Syscall structures in our context. We use C99 designated initializers
-	// for clarity and to ensure the correct fields are populated.
-	// The remaining fields (dwSyscallNr, pStub) are zero-initialized by the LOADER_CONTEXT
-	// initialization and will be populated later by getSyscalls().
-	context.Syscalls[SyscallIndexAllocateVirtualMemory] = (Syscall){.dwCryptedHash = ZWALLOCATEVIRTUALMEMORY_HASH, .dwNumberOfArgs = 6};
-	context.Syscalls[SyscallIndexProtectVirtualMemory] = (Syscall){.dwCryptedHash = ZWPROTECTVIRTUALMEMORY_HASH, .dwNumberOfArgs = 5};
-	context.Syscalls[SyscallIndexFlushInstructionCache] = (Syscall){.dwCryptedHash = ZWFLUSHINSTRUCTIONCACHE_HASH, .dwNumberOfArgs = 3};
+	// Initialize the Syscall structures in our context.
+	// We use explicit member assignment instead of C99 designated initializers
+	// to maintain compatibility with C++ compilers (pre-C++20), which do not
+	// support this feature. The entire struct is first zero-initialized.
+	context.Syscalls[SyscallIndexAllocateVirtualMemory] = (Syscall){0};
+	context.Syscalls[SyscallIndexAllocateVirtualMemory].dwCryptedHash = ZWALLOCATEVIRTUALMEMORY_HASH;
+	context.Syscalls[SyscallIndexAllocateVirtualMemory].dwNumberOfArgs = 6;
+	context.Syscalls[SyscallIndexAllocateVirtualMemory].dwSyscallNr = 0; // Explicitly zeroed for clarity
+	context.Syscalls[SyscallIndexAllocateVirtualMemory].pStub = NULL;	 // Explicitly zeroed for clarity
+
+	context.Syscalls[SyscallIndexProtectVirtualMemory] = (Syscall){0};
+	context.Syscalls[SyscallIndexProtectVirtualMemory].dwCryptedHash = ZWPROTECTVIRTUALMEMORY_HASH;
+	context.Syscalls[SyscallIndexProtectVirtualMemory].dwNumberOfArgs = 5;
+	context.Syscalls[SyscallIndexProtectVirtualMemory].dwSyscallNr = 0;
+	context.Syscalls[SyscallIndexProtectVirtualMemory].pStub = NULL;
+
+	context.Syscalls[SyscallIndexFlushInstructionCache] = (Syscall){0};
+	context.Syscalls[SyscallIndexFlushInstructionCache].dwCryptedHash = ZWFLUSHINSTRUCTIONCACHE_HASH;
+	context.Syscalls[SyscallIndexFlushInstructionCache].dwNumberOfArgs = 3;
+	context.Syscalls[SyscallIndexFlushInstructionCache].dwSyscallNr = 0;
+	context.Syscalls[SyscallIndexFlushInstructionCache].pStub = NULL;
+
 #ifdef ENABLE_STOPPAGING
-	context.Syscalls[SyscallIndexLockVirtualMemory] = (Syscall){.dwCryptedHash = ZWLOCKVIRTUALMEMORY_HASH, .dwNumberOfArgs = 4};
+	context.Syscalls[SyscallIndexLockVirtualMemory] = (Syscall){0};
+	context.Syscalls[SyscallIndexLockVirtualMemory].dwCryptedHash = ZWLOCKVIRTUALMEMORY_HASH;
+	context.Syscalls[SyscallIndexLockVirtualMemory].dwNumberOfArgs = 4;
+	context.Syscalls[SyscallIndexLockVirtualMemory].dwSyscallNr = 0;
+	context.Syscalls[SyscallIndexLockVirtualMemory].pStub = NULL;
 #endif
 
 	// STEP 0: Find our own image base in memory.

--- a/dll/src/ReflectiveLoader.c
+++ b/dll/src/ReflectiveLoader.c
@@ -454,35 +454,30 @@ RDIDLLEXPORT ULONG_PTR WINAPI ReflectiveLoader(VOID)
 #endif
 {
 	LOADER_CONTEXT context = {0};
+	// Create a single, zero-initialized template struct using legal syntax.
+	// This is portable to both C and C++ compilers.
+	static const Syscall zeroed_syscall = { 0 };
 
 	// Initialize the Syscall structures in our context.
-	// We use explicit member assignment instead of C99 designated initializers
-	// to maintain compatibility with C++ compilers (pre-C++20), which do not
-	// support this feature. The entire struct is first zero-initialized.
-	context.Syscalls[SyscallIndexAllocateVirtualMemory] = (Syscall){0};
+	// We assign a pre-zeroed struct to ensure portability across C/C++
+	// compilers, avoiding non-standard C99 compound literals or illegal
+	// initializer-list assignments.
+	context.Syscalls[SyscallIndexAllocateVirtualMemory] = zeroed_syscall;
 	context.Syscalls[SyscallIndexAllocateVirtualMemory].dwCryptedHash = ZWALLOCATEVIRTUALMEMORY_HASH;
 	context.Syscalls[SyscallIndexAllocateVirtualMemory].dwNumberOfArgs = 6;
-	context.Syscalls[SyscallIndexAllocateVirtualMemory].dwSyscallNr = 0; // Explicitly zeroed for clarity
-	context.Syscalls[SyscallIndexAllocateVirtualMemory].pStub = NULL;	 // Explicitly zeroed for clarity
 
-	context.Syscalls[SyscallIndexProtectVirtualMemory] = (Syscall){0};
+	context.Syscalls[SyscallIndexProtectVirtualMemory] = zeroed_syscall;
 	context.Syscalls[SyscallIndexProtectVirtualMemory].dwCryptedHash = ZWPROTECTVIRTUALMEMORY_HASH;
 	context.Syscalls[SyscallIndexProtectVirtualMemory].dwNumberOfArgs = 5;
-	context.Syscalls[SyscallIndexProtectVirtualMemory].dwSyscallNr = 0;
-	context.Syscalls[SyscallIndexProtectVirtualMemory].pStub = NULL;
 
-	context.Syscalls[SyscallIndexFlushInstructionCache] = (Syscall){0};
+	context.Syscalls[SyscallIndexFlushInstructionCache] = zeroed_syscall;
 	context.Syscalls[SyscallIndexFlushInstructionCache].dwCryptedHash = ZWFLUSHINSTRUCTIONCACHE_HASH;
 	context.Syscalls[SyscallIndexFlushInstructionCache].dwNumberOfArgs = 3;
-	context.Syscalls[SyscallIndexFlushInstructionCache].dwSyscallNr = 0;
-	context.Syscalls[SyscallIndexFlushInstructionCache].pStub = NULL;
 
 #ifdef ENABLE_STOPPAGING
-	context.Syscalls[SyscallIndexLockVirtualMemory] = (Syscall){0};
+	context.Syscalls[SyscallIndexLockVirtualMemory] = zeroed_syscall;
 	context.Syscalls[SyscallIndexLockVirtualMemory].dwCryptedHash = ZWLOCKVIRTUALMEMORY_HASH;
 	context.Syscalls[SyscallIndexLockVirtualMemory].dwNumberOfArgs = 4;
-	context.Syscalls[SyscallIndexLockVirtualMemory].dwSyscallNr = 0;
-	context.Syscalls[SyscallIndexLockVirtualMemory].pStub = NULL;
 #endif
 
 	// STEP 0: Find our own image base in memory.

--- a/dll/src/ReflectiveLoader.c
+++ b/dll/src/ReflectiveLoader.c
@@ -167,7 +167,6 @@ static DWORD _resolve_dependencies(PLOADER_CONTEXT pContext)
 	// Ref: https://learn.microsoft.com/en-us/windows/win32/api/winternl/ns-winternl-peb_ldr_data
 	uiBaseAddress = (ULONG_PTR)((_PPEB)uiBaseAddress)->pLdr;
 
-	// Use a descriptive name for the list entry pointer.
 	ULONG_PTR pModuleListEntry = (ULONG_PTR)((PPEB_LDR_DATA)uiBaseAddress)->InMemoryOrderModuleList.Flink;
 
 	// Iterate through the loaded modules to find kernel32.dll and ntdll.dll by hash.
@@ -175,7 +174,6 @@ static DWORD _resolve_dependencies(PLOADER_CONTEXT pContext)
 	{
 		PLDR_DATA_TABLE_ENTRY pLdrEntry = (PLDR_DATA_TABLE_ENTRY)pModuleListEntry;
 
-		// Use descriptive names for hashing variables.
 		ULONG_PTR pModuleName = (ULONG_PTR)pLdrEntry->BaseDllName.pBuffer;
 		DWORD dwModuleHash = 0;
 		usCounter = pLdrEntry->BaseDllName.Length;

--- a/inject/inject.vcxproj
+++ b/inject/inject.vcxproj
@@ -5,6 +5,10 @@
       <Configuration>Debug</Configuration>
       <Platform>ARM</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
@@ -16,6 +20,10 @@
     <ProjectConfiguration Include="Release|ARM">
       <Configuration>Release</Configuration>
       <Platform>ARM</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
     </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
@@ -35,35 +43,46 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
@@ -84,7 +103,13 @@
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
@@ -107,6 +132,12 @@
     <LinkIncremental>true</LinkIncremental>
     <TargetName>$(ProjectName).$(Platform)</TargetName>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <LinkIncremental>true</LinkIncremental>
+    <TargetName>$(ProjectName).$(Platform)</TargetName>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
     <IntDir>$(Configuration)\</IntDir>
@@ -118,6 +149,12 @@
     <TargetName>$(ProjectName).$(Platform)</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <LinkIncremental>false</LinkIncremental>
+    <TargetName>$(ProjectName).$(Platform)</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\</IntDir>
     <LinkIncremental>false</LinkIncremental>
@@ -186,6 +223,26 @@
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
     </Link>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <Midl />
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_DEBUG;_WIN64;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>false</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>EnableAllWarnings</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalIncludeDirectories>../common</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
+    </Link>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <Optimization>Custom</Optimization>
@@ -249,7 +306,7 @@
       <TargetEnvironment>X64</TargetEnvironment>
     </Midl>
     <ClCompile>
-      <Optimization>Custom</Optimization>
+      <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>false</IntrinsicFunctions>
       <PreprocessorDefinitions>_CONSOLE;_WIN64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -284,9 +341,50 @@
       </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <Midl />
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <IntrinsicFunctions>false</IntrinsicFunctions>
+      <PreprocessorDefinitions>_CONSOLE;_WIN64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>EnableAllWarnings</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalIncludeDirectories>../common</AdditionalIncludeDirectories>
+      <WholeProgramOptimization>false</WholeProgramOptimization>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FavorSizeOrSpeed>Size</FavorSizeOrSpeed>
+      <OmitFramePointers>true</OmitFramePointers>
+      <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
+      <StringPooling>true</StringPooling>
+      <AdditionalOptions>/Og %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+    <Link>
+      <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <StackReserveSize>
+      </StackReserveSize>
+      <StackCommitSize>
+      </StackCommitSize>
+      <LinkTimeCodeGeneration>
+      </LinkTimeCodeGeneration>
+    </Link>
+    <PostBuildEvent>
+      <Command>
+      </Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="src\GetProcAddressR.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+      </ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
       </ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
       </ExcludedFromBuild>
@@ -298,6 +396,8 @@
       </ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
       </ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+      </ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="src\LoadLibraryR.c" />
   </ItemGroup>
@@ -307,6 +407,8 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
       </ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+      </ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
       </ExcludedFromBuild>
     </ClInclude>
     <ClInclude Include="src\LoadLibraryR.h" />

--- a/inject/src/GetProcAddressR.c
+++ b/inject/src/GetProcAddressR.c
@@ -1,4 +1,3 @@
-//===============================================================================================//
 // Copyright (c) 2013, Stephen Fewer of Harmony Security (www.harmonysecurity.com)
 // All rights reserved.
 //
@@ -27,96 +26,88 @@
 //===============================================================================================//
 #include "GetProcAddressR.h"
 
-#ifdef __MINGW32__
-#define __try
-#define __except(x) if(0)
-#endif
-
-//===============================================================================================//
-// We implement a minimal GetProcAddress to avoid using the native kernel32!GetProcAddress which
-// wont be able to resolve exported addresses in reflectivly loaded librarys.
-FARPROC WINAPI GetProcAddressR( HANDLE hModule, LPCSTR lpProcName )
+FARPROC WINAPI GetProcAddressR(HANDLE hModule, LPCSTR lpProcName)
 {
-	UINT_PTR uiLibraryAddress = 0;
-	FARPROC fpResult          = NULL;
-
-	if( hModule == NULL )
+	if (!hModule || !lpProcName)
 		return NULL;
 
-	// a module handle is really its base address
-	uiLibraryAddress = (UINT_PTR)hModule;
+	UINT_PTR uiLibraryAddress = (UINT_PTR)hModule;
+	PIMAGE_DOS_HEADER pDosHeader = (PIMAGE_DOS_HEADER)uiLibraryAddress;
+	PIMAGE_NT_HEADERS pNtHeaders = NULL;
+	PIMAGE_EXPORT_DIRECTORY pExportDirectory = NULL;
 
-	__try
+	// STEP 1: Validate the PE headers to ensure we are parsing a valid module.
+	if (pDosHeader->e_magic != IMAGE_DOS_SIGNATURE)
+		return NULL;
+
+	pNtHeaders = (PIMAGE_NT_HEADERS)(uiLibraryAddress + pDosHeader->e_lfanew);
+	if (pNtHeaders->Signature != IMAGE_NT_SIGNATURE)
+		return NULL;
+
+	// STEP 2: Locate the Export Address Table (EAT). If the module has no exports, return NULL.
+	PIMAGE_DATA_DIRECTORY pDataDirectory = &pNtHeaders->OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_EXPORT];
+	if (pDataDirectory->VirtualAddress == 0)
+		return NULL;
+
+	pExportDirectory = (PIMAGE_EXPORT_DIRECTORY)(uiLibraryAddress + pDataDirectory->VirtualAddress);
+
+	// STEP 3: Get pointers to the three critical arrays within the EAT.
+	// AddressOfFunctions: RVAs to the actual function code.
+	PDWORD pdwAddressArray = (PDWORD)(uiLibraryAddress + pExportDirectory->AddressOfFunctions);
+	// AddressOfNames: RVAs to the function name strings.
+	PDWORD pdwNameArray = (PDWORD)(uiLibraryAddress + pExportDirectory->AddressOfNames);
+	// AddressOfNameOrdinals: An array of WORDs that maps names to ordinals.
+	PWORD pwNameOrdinals = (PWORD)(uiLibraryAddress + pExportDirectory->AddressOfNameOrdinals);
+
+	// STEP 4: Determine if the function is being imported by name or by ordinal.
+	// The IS_INTRESOURCE macro checks if the high-word is zero.
+	if (((DWORD_PTR)lpProcName >> 16) == 0)
 	{
-		UINT_PTR uiAddressArray = 0;
-		UINT_PTR uiNameArray    = 0;
-		UINT_PTR uiNameOrdinals = 0;
-		PIMAGE_NT_HEADERS pNtHeaders             = NULL;
-		PIMAGE_DATA_DIRECTORY pDataDirectory     = NULL;
-		PIMAGE_EXPORT_DIRECTORY pExportDirectory = NULL;
+		// The ordinal is the low-word of the lpProcName parameter.
+		WORD wOrdinal = (WORD)lpProcName;
+		DWORD dwOrdinalBase = pExportDirectory->Base;
 
-		// get the VA of the modules NT Header
-		pNtHeaders = (PIMAGE_NT_HEADERS)(uiLibraryAddress + ((PIMAGE_DOS_HEADER)uiLibraryAddress)->e_lfanew);
+		// Check if the requested ordinal is within the valid range of exported functions.
+		if (wOrdinal < dwOrdinalBase || wOrdinal >= dwOrdinalBase + pExportDirectory->NumberOfFunctions)
+			return NULL;
 
-		pDataDirectory = (PIMAGE_DATA_DIRECTORY)&pNtHeaders->OptionalHeader.DataDirectory[ IMAGE_DIRECTORY_ENTRY_EXPORT ];
+		// The function's RVA is found by indexing the address table with (requested_ordinal - base_ordinal).
+		DWORD dwFunctionRva = pdwAddressArray[wOrdinal - dwOrdinalBase];
 
-		// get the VA of the export directory
-		pExportDirectory = (PIMAGE_EXPORT_DIRECTORY)( uiLibraryAddress + pDataDirectory->VirtualAddress );
+		// An RVA of 0 indicates a gap in the ordinal table (a function that is not implemented).
+		if (dwFunctionRva == 0)
+			return NULL;
 
-		// get the VA for the array of addresses
-		uiAddressArray = ( uiLibraryAddress + pExportDirectory->AddressOfFunctions );
-
-		// get the VA for the array of name pointers
-		uiNameArray = ( uiLibraryAddress + pExportDirectory->AddressOfNames );
-
-		// get the VA for the array of name ordinals
-		uiNameOrdinals = ( uiLibraryAddress + pExportDirectory->AddressOfNameOrdinals );
-
-		// test if we are importing by name or by ordinal...
-		if( (((DWORD_PTR)lpProcName) >> 16) == 0 )
+		// Return the absolute address of the function.
+		return (FARPROC)(uiLibraryAddress + dwFunctionRva);
+	}
+	else
+	{
+		// Iterate through the array of exported function names.
+		for (DWORD i = 0; i < pExportDirectory->NumberOfNames; i++)
 		{
-			// import by ordinal...
+			LPCSTR cpExportedFunctionName = (LPCSTR)(uiLibraryAddress + pdwNameArray[i]);
 
-			// use the import ordinal (- export ordinal base) as an index into the array of addresses
-			uiAddressArray += ( ( IMAGE_ORDINAL( (DWORD)(DWORD_PTR)lpProcName ) - pExportDirectory->Base ) * sizeof(DWORD) );
-
-			// resolve the address for this imported function
-			fpResult = (FARPROC)( uiLibraryAddress + DEREF_32(uiAddressArray) );
-		}
-		else
-		{
-			// import by name...
-			DWORD dwCounter = pExportDirectory->NumberOfNames;
-			while( dwCounter-- )
+			// Perform a case-sensitive string comparison to find a match.
+			if (strcmp(cpExportedFunctionName, lpProcName) == 0)
 			{
-				char * cpExportedFunctionName = (char *)(uiLibraryAddress + DEREF_32( uiNameArray ));
+				// Match found. The index 'i' is the key to link the three arrays.
+				// Use 'i' to get the function's ordinal from the name ordinals array.
+				WORD wFunctionOrdinal = pwNameOrdinals[i];
 
-				// test if we have a match...
-				if( strcmp( cpExportedFunctionName, lpProcName ) == 0 )
-				{
-					// use the functions name ordinal as an index into the array of name pointers
-					uiAddressArray += ( DEREF_16( uiNameOrdinals ) * sizeof(DWORD) );
+				// Use the ordinal to get the function's RVA from the address table.
+				DWORD dwFunctionRva = pdwAddressArray[wFunctionOrdinal];
 
-					// calculate the virtual address for the function
-					fpResult = (FARPROC)(uiLibraryAddress + DEREF_32( uiAddressArray ));
+				// This should not happen for a named export, but as a safeguard.
+				if (dwFunctionRva == 0)
+					return NULL;
 
-					// finish...
-					break;
-				}
-
-				// get the next exported function name
-				uiNameArray += sizeof(DWORD);
-
-				// get the next exported function name ordinal
-				uiNameOrdinals += sizeof(WORD);
+				// Return the absolute address of the function.
+				return (FARPROC)(uiLibraryAddress + dwFunctionRva);
 			}
 		}
 	}
-	__except( EXCEPTION_EXECUTE_HANDLER )
-	{
-		fpResult = NULL;
-	}
 
-	return fpResult;
+	// The requested function was not found in the export table.
+	return NULL;
 }
-//===============================================================================================//

--- a/inject/src/Inject.c
+++ b/inject/src/Inject.c
@@ -1,28 +1,28 @@
 //===============================================================================================//
 // Copyright (c) 2013, Stephen Fewer of Harmony Security (www.harmonysecurity.com)
 // All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without modification, are permitted 
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted
 // provided that the following conditions are met:
-// 
-//     * Redistributions of source code must retain the above copyright notice, this list of 
+//
+//     * Redistributions of source code must retain the above copyright notice, this list of
 // conditions and the following disclaimer.
-// 
-//     * Redistributions in binary form must reproduce the above copyright notice, this list of 
-// conditions and the following disclaimer in the documentation and/or other materials provided 
+//
+//     * Redistributions in binary form must reproduce the above copyright notice, this list of
+// conditions and the following disclaimer in the documentation and/or other materials provided
 // with the distribution.
-// 
+//
 //     * Neither the name of Harmony Security nor the names of its contributors may be used to
 // endorse or promote products derived from this software without specific prior written permission.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR 
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
 // IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
-// FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR 
-// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+// FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //===============================================================================================//
 #define WIN32_LEAN_AND_MEAN
@@ -32,96 +32,167 @@
 #include "LoadLibraryR.h"
 
 #ifndef __MINGW32__
-#pragma comment(lib,"Advapi32.lib")
+#pragma comment(lib, "Advapi32.lib")
 #endif
 
-#define BREAK_WITH_ERROR( e ) { printf( "[-] %s. Error=%ld", e, GetLastError() ); break; }
-
-// Simple app to inject a reflective DLL into a process vis its process ID.
-int main( int argc, char * argv[] )
+// Attempts to enable the SE_DEBUG_NAME privilege. This is necessary for opening
+// handles to processes with higher privileges (e.g., system services).
+static BOOL EnableDebugPrivilege()
 {
-	HANDLE hFile          = NULL;
-	HANDLE hModule        = NULL;
-	HANDLE hProcess       = NULL;
-	HANDLE hToken         = NULL;
-	LPVOID lpBuffer       = NULL;
-	DWORD dwLength        = 0;
-	DWORD dwBytesRead     = 0;
-	DWORD dwProcessId     = 0;
-	TOKEN_PRIVILEGES priv = {0};
-
-#ifdef _WIN64
-	char * cpDllFile  = "reflective_dll.x64.dll";
-#else
-#ifdef WIN32
-	char * cpDllFile  = "reflective_dll.Win32.dll";
-#else WIN_ARM
-	char * cpDllFile  = "reflective_dll.arm.dll";
-#endif
-#endif
-
-
-	do
+	HANDLE hToken = NULL;
+	if (!OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, &hToken))
 	{
-		// Usage: inject.exe [pid] [dll_file]
+		return FALSE;
+	}
 
-		if( argc == 1 )
-			dwProcessId = GetCurrentProcessId();
-		else
-			dwProcessId = atoi( argv[1] );
+	TOKEN_PRIVILEGES priv = {0};
+	priv.PrivilegeCount = 1;
+	priv.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
 
-		if( argc >= 3 )
-			cpDllFile = argv[2];
+	if (LookupPrivilegeValue(NULL, SE_DEBUG_NAME, &priv.Privileges[0].Luid))
+	{
+		// This function may not succeed, but we don't check the return value
+		// as we want to proceed even if it fails. The OpenProcess call will
+		// ultimately determine if we have sufficient rights.
+		AdjustTokenPrivileges(hToken, FALSE, &priv, 0, NULL, NULL);
+	}
 
-		hFile = CreateFileA( cpDllFile, GENERIC_READ, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL );
-		if( hFile == INVALID_HANDLE_VALUE )
-			BREAK_WITH_ERROR( "Failed to open the DLL file" );
+	CloseHandle(hToken);
+	// We return true even if AdjustTokenPrivileges fails, to allow injection
+	// into processes with the same or lower privilege level.
+	return TRUE;
+}
 
-		dwLength = GetFileSize( hFile, NULL );
-		if( dwLength == INVALID_FILE_SIZE || dwLength == 0 )
-			BREAK_WITH_ERROR( "Failed to get the DLL file size" );
+// A simple command-line tool to inject a reflective DLL into a target process.
+int main(int argc, char *argv[])
+{
+	HANDLE hFile = NULL;
+	HANDLE hProcess = NULL;
+	HANDLE hThread = NULL;
+	LPVOID lpBuffer = NULL;
+	DWORD dwProcessId = 0;
+	char *cpDllFile = NULL;
+	int exitCode = 1; // Default to error exit code
 
-		lpBuffer = HeapAlloc( GetProcessHeap(), 0, dwLength );
-		if( !lpBuffer )
-			BREAK_WITH_ERROR( "Failed to get the DLL file size" );
+	// Set the default DLL name based on the architecture of this injector.
+	// This ensures we inject a DLL of the same architecture.
+#if defined(_M_X64)
+	cpDllFile = "reflective_dll.x64.dll";
+#elif defined(_M_ARM64)
+	cpDllFile = "reflective_dll.arm64.dll";
+#elif defined(_M_IX86)
+	cpDllFile = "reflective_dll.Win32.dll";
+#elif defined(_M_ARM)
+	cpDllFile = "reflective_dll.arm.dll";
+#else
+#error "Unsupported architecture."
+#endif
 
-		if( ReadFile( hFile, lpBuffer, dwLength, &dwBytesRead, NULL ) == FALSE )
-			BREAK_WITH_ERROR( "Failed to alloc a buffer!" );
+	printf("[*] Reflective DLL Injection Tool\n");
 
-		if( OpenProcessToken( GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, &hToken ) )
+	// Parse command line: inject.exe [pid] [dll_path]
+	if (argc == 1)
+	{
+		dwProcessId = GetCurrentProcessId();
+		printf("[+] No PID specified. Defaulting to current process ID: %ld\n", dwProcessId);
+	}
+	else
+	{
+		dwProcessId = atoi(argv[1]);
+	}
+
+	if (argc >= 3)
+	{
+		cpDllFile = argv[2];
+	}
+
+	printf("[+] Attempting to inject '%s' into process %ld...\n", cpDllFile, dwProcessId);
+
+	// STAGE 1: Read the target DLL from disk into a local buffer.
+	hFile = CreateFileA(cpDllFile, GENERIC_READ, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+	if (hFile == INVALID_HANDLE_VALUE)
+	{
+		printf("[-] Failed to open the DLL file '%s'. Error: %ld\n", cpDllFile, GetLastError());
+		goto cleanup;
+	}
+
+	DWORD dwLength = GetFileSize(hFile, NULL);
+	if (dwLength == INVALID_FILE_SIZE || dwLength == 0)
+	{
+		printf("[-] Failed to get the DLL file size. Error: %ld\n", GetLastError());
+		goto cleanup;
+	}
+
+	lpBuffer = HeapAlloc(GetProcessHeap(), 0, dwLength);
+	if (!lpBuffer)
+	{
+		printf("[-] Failed to allocate buffer for DLL. Error: %ld\n", GetLastError());
+		goto cleanup;
+	}
+
+	DWORD dwBytesRead = 0;
+	if (!ReadFile(hFile, lpBuffer, dwLength, &dwBytesRead, NULL) || dwBytesRead != dwLength)
+	{
+		printf("[-] Failed to read the DLL file into buffer. Error: %ld\n", GetLastError());
+		goto cleanup;
+	}
+
+	// STAGE 2: Prepare for injection by enabling debug privileges and opening the target process.
+	if (!EnableDebugPrivilege())
+	{
+		printf("[!] Warning: Failed to enable SeDebugPrivilege. Injection may fail for protected processes.\n");
+	}
+
+	hProcess = OpenProcess(PROCESS_CREATE_THREAD | PROCESS_QUERY_INFORMATION | PROCESS_VM_OPERATION | PROCESS_VM_WRITE | PROCESS_VM_READ, FALSE, dwProcessId);
+	if (!hProcess)
+	{
+		printf("[-] Failed to open the target process. Error: %ld\n", GetLastError());
+		goto cleanup;
+	}
+	printf("[+] Target process handle obtained: 0x%p\n", hProcess);
+
+	// STAGE 3: Inject the DLL and execute its reflective loader.
+	hThread = LoadRemoteLibraryR(hProcess, lpBuffer, dwLength, "ReflectiveLoader", NULL);
+	if (!hThread)
+	{
+		printf("[-] Failed to inject the DLL. LoadRemoteLibraryR failed with error: %ld\n", GetLastError());
+		goto cleanup;
+	}
+	printf("[+] Injection successful. Remote thread created with handle: 0x%p\n", hThread);
+	printf("[+] Waiting for remote thread to terminate...\n");
+
+	WaitForSingleObject(hThread, INFINITE);
+	printf("[+] Remote thread has terminated.\n");
+
+	// STAGE 4: Get and report the exit code of the remote loader thread for diagnostics.
+	DWORD dwRemoteExitCode = 0;
+	if (GetExitCodeThread(hThread, &dwRemoteExitCode))
+	{
+		printf("[+] Remote thread exit code: 0x%08lX\n", dwRemoteExitCode);
+		// A high-bit error code indicates a failure inside the reflective loader.
+		if ((dwRemoteExitCode & 0xF0000000) == 0xE0000000)
 		{
-			priv.PrivilegeCount           = 1;
-			priv.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
-		
-			if( LookupPrivilegeValue( NULL, SE_DEBUG_NAME, &priv.Privileges[0].Luid ) )
-				AdjustTokenPrivileges( hToken, FALSE, &priv, 0, NULL, NULL );
-
-			CloseHandle( hToken );
+			printf("[-] ReflectiveLoader failed with internal error code: 0x%lX\n", dwRemoteExitCode);
 		}
+	}
+	else
+	{
+		printf("[-] Failed to get remote thread exit code. Error: %ld\n", GetLastError());
+	}
 
-		hProcess = OpenProcess( PROCESS_CREATE_THREAD | PROCESS_QUERY_INFORMATION | PROCESS_VM_OPERATION | PROCESS_VM_WRITE | PROCESS_VM_READ, FALSE, dwProcessId );
-		if( !hProcess )
-			BREAK_WITH_ERROR( "Failed to open the target process" );
+	exitCode = 0; // Set success exit code for the injector itself.
 
-		hModule = LoadRemoteLibraryR( hProcess, lpBuffer, dwLength, "ReflectiveLoader", NULL );
-		//hModule = LoadRemoteLibraryR( hProcess, lpBuffer, dwLength, MAKEINTRESOURCE(1), NULL );
-		if( !hModule )
-			BREAK_WITH_ERROR( "Failed to inject the DLL" );
-
-		printf( "[+] Injected the '%s' DLL into process %ld.\n", cpDllFile, dwProcessId );
-		
-		WaitForSingleObject( hModule, (DWORD) -1 );
-
-	} while( 0 );
-	
+cleanup:
+	// STAGE 5: Clean up all opened handles and allocated memory.
+	if (hThread)
+		CloseHandle(hThread);
+	if (hProcess)
+		CloseHandle(hProcess);
+	if (lpBuffer)
+		HeapFree(GetProcessHeap(), 0, lpBuffer);
 	if (hFile)
 		CloseHandle(hFile);
-	
-	if( lpBuffer )
-		HeapFree( GetProcessHeap(), 0, lpBuffer );
 
-	if( hProcess )
-		CloseHandle( hProcess );
-
-	return 0;
+	printf("[*] Finished.\n");
+	return exitCode;
 }

--- a/rdi.sln
+++ b/rdi.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.33801.447
+# Visual Studio Version 17
+VisualStudioVersion = 17.14.36212.18 d17.14
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "inject", "inject\inject.vcxproj", "{EEF3FD41-05D8-4A07-8434-EF5D34D76335}"
 EndProject
@@ -10,33 +10,43 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM = Debug|ARM
+		Debug|ARM64 = Debug|ARM64
 		Debug|Win32 = Debug|Win32
 		Debug|x64 = Debug|x64
 		Release|ARM = Release|ARM
+		Release|ARM64 = Release|ARM64
 		Release|Win32 = Release|Win32
 		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{EEF3FD41-05D8-4A07-8434-EF5D34D76335}.Debug|ARM.ActiveCfg = Release|ARM
 		{EEF3FD41-05D8-4A07-8434-EF5D34D76335}.Debug|ARM.Build.0 = Release|ARM
+		{EEF3FD41-05D8-4A07-8434-EF5D34D76335}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{EEF3FD41-05D8-4A07-8434-EF5D34D76335}.Debug|ARM64.Build.0 = Debug|ARM64
 		{EEF3FD41-05D8-4A07-8434-EF5D34D76335}.Debug|Win32.ActiveCfg = Debug|Win32
 		{EEF3FD41-05D8-4A07-8434-EF5D34D76335}.Debug|Win32.Build.0 = Debug|Win32
 		{EEF3FD41-05D8-4A07-8434-EF5D34D76335}.Debug|x64.ActiveCfg = Debug|x64
 		{EEF3FD41-05D8-4A07-8434-EF5D34D76335}.Debug|x64.Build.0 = Debug|x64
 		{EEF3FD41-05D8-4A07-8434-EF5D34D76335}.Release|ARM.ActiveCfg = Release|ARM
 		{EEF3FD41-05D8-4A07-8434-EF5D34D76335}.Release|ARM.Build.0 = Release|ARM
+		{EEF3FD41-05D8-4A07-8434-EF5D34D76335}.Release|ARM64.ActiveCfg = Release|ARM64
+		{EEF3FD41-05D8-4A07-8434-EF5D34D76335}.Release|ARM64.Build.0 = Release|ARM64
 		{EEF3FD41-05D8-4A07-8434-EF5D34D76335}.Release|Win32.ActiveCfg = Release|Win32
 		{EEF3FD41-05D8-4A07-8434-EF5D34D76335}.Release|Win32.Build.0 = Release|Win32
 		{EEF3FD41-05D8-4A07-8434-EF5D34D76335}.Release|x64.ActiveCfg = Release|x64
 		{EEF3FD41-05D8-4A07-8434-EF5D34D76335}.Release|x64.Build.0 = Release|x64
 		{3A371EBD-EEE1-4B2A-88B9-93E7BABE0949}.Debug|ARM.ActiveCfg = Release|ARM
 		{3A371EBD-EEE1-4B2A-88B9-93E7BABE0949}.Debug|ARM.Build.0 = Release|ARM
+		{3A371EBD-EEE1-4B2A-88B9-93E7BABE0949}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{3A371EBD-EEE1-4B2A-88B9-93E7BABE0949}.Debug|ARM64.Build.0 = Debug|ARM64
 		{3A371EBD-EEE1-4B2A-88B9-93E7BABE0949}.Debug|Win32.ActiveCfg = Debug|Win32
 		{3A371EBD-EEE1-4B2A-88B9-93E7BABE0949}.Debug|Win32.Build.0 = Debug|Win32
 		{3A371EBD-EEE1-4B2A-88B9-93E7BABE0949}.Debug|x64.ActiveCfg = Debug|x64
 		{3A371EBD-EEE1-4B2A-88B9-93E7BABE0949}.Debug|x64.Build.0 = Debug|x64
 		{3A371EBD-EEE1-4B2A-88B9-93E7BABE0949}.Release|ARM.ActiveCfg = Release|ARM
 		{3A371EBD-EEE1-4B2A-88B9-93E7BABE0949}.Release|ARM.Build.0 = Release|ARM
+		{3A371EBD-EEE1-4B2A-88B9-93E7BABE0949}.Release|ARM64.ActiveCfg = Release|ARM64
+		{3A371EBD-EEE1-4B2A-88B9-93E7BABE0949}.Release|ARM64.Build.0 = Release|ARM64
 		{3A371EBD-EEE1-4B2A-88B9-93E7BABE0949}.Release|Win32.ActiveCfg = Release|Win32
 		{3A371EBD-EEE1-4B2A-88B9-93E7BABE0949}.Release|Win32.Build.0 = Release|Win32
 		{3A371EBD-EEE1-4B2A-88B9-93E7BABE0949}.Release|x64.ActiveCfg = Release|x64


### PR DESCRIPTION
**Description:**

This pull request represents a modernization and architectural expansion of the ReflectiveDLLInjection library. The primary achievement is the introduction of **full support for the ARM64 architecture**, making this one of the first (or first?) public, open-source implementations to use a direct syscall mechanism on Windows on ARM64.

Beyond ARM64 support, this update includes a refactoring of the existing codebase for all platforms (x86, x64, ARM, ARM64). The focus has been on improving maintainability, robustness, and readability while **strictly preserving all existing public symbols and API contracts** to ensure zero breakage for Metasploit and other downstream integrations.

A special thanks to **@dledda-r7** for his brilliant insight, which was instrumental in making a true direct syscall implementation possible.

**Key Changes & Benefits:**

*   **Full ARM64 Architecture Support:**
    *   The core reflective loader (`ReflectiveLoader.c`) and the direct syscall resolver (`DirectSyscall.c`) now contain dedicated logic for the ARM64 platform.
    *   A new assembly trampoline (`GateTrampolineARM64.asm`) has been implemented to correctly bridge the C calling convention with the ARM64 syscall ABI.

*   **Unified, Multi-Architecture Direct Syscall Framework:**
    *   **Architecture-Specific Stub Verification:**
        *   **x86/x64:** The existing, proven method of calculating a fixed offset to the `syscall; ret` gadget is maintained.
        *   **ARM64:** A new verification mechanism has been implemented. It uses a reverse-engineered formula (`expected_opcode = 0xd4000001 + (syscall_number * 0x20)`) to confirm that the `svc #<imm>` instruction at a function's address is an authentic, unhooked syscall stub.

*   **Refactoring for Maintainability and Robustness:**
    *   **`ReflectiveLoader.c`:** The monolithic loader function has been decomposed into smaller, static helper functions, dramatically improving code clarity. A `LOADER_CONTEXT` struct was introduced to manage state cleanly.
    *   **`Inject.c`:** The example injector has been modernized, replacing the `do-while(0)` loop with a standard `goto cleanup` pattern for error handling. It also now correctly identifies the default ARM64 DLL name.
    *   **`LoadLibraryR.c` / `GetProcAddressR.c`:** These components were refactored to remove non-standard `__try`/`__except` blocks, replacing them with explicit pointer validation. A PE parsing bug related to `VirtualSize` vs. `SizeOfRawData` was fixed, enhancing reliability across all platforms.

*   **Advanced Debugging and Diagnostics:**
    *   The reflective loader was instrumented with a system of error codes returned via the remote thread's exit code. This allowed for a debugging process to isolate and fix the subtle, platform-specific bugs on ARM64. Happy to remove that in the final version though. :)
    *   The injector was updated to read and display these exit codes, providing diagnostics for any potential failures.

**Testing Summary:**

The following tests were performed to validate the unified, multi-architecture implementation. The entire process, from finding the image base to calling the final entry point, was successful on both x64 and ARM64.

| Architecture | Test Case                     | Result                             | Notes                                                                               |
| :----------- | :---------------------------- | :--------------------------------- | :---------------------------------------------------------------------------------- |
| **x64**      | Local Injector (`Inject.exe`) | **SUCCESS** (MessageBox displayed) | Injected `reflective_dll.x64.dll` into `inject.x64.exe` (self-injection).           |
| **x64**      | Metasploit (post/windows/manage/reflective\_dll\_inject) | **SUCCESS** (MessageBox displayed) | Injected `reflective_dll.x64.dll` (with MessageBox) into `powershell.exe`. |
| **ARM64**    | Local Injector (`Inject.exe`) | **SUCCESS** (MessageBox displayed) | Injected `reflective_dll.arm64.dll` into `inject.arm64.exe` (self-injection).       |
