### PR TITLE
Update DirectSyscall to a new format

### DIFF
--- a/common/ReflectiveDLLInjection.h
+++ b/common/ReflectiveDLLInjection.h
@@ -25,6 +25,7 @@
 // OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //===============================================================================================//
+#pragma clang optimize off
 #ifndef _REFLECTIVEDLLINJECTION_REFLECTIVEDLLINJECTION_H
 #define _REFLECTIVEDLLINJECTION_REFLECTIVEDLLINJECTION_H
 //===============================================================================================//

--- a/common/ReflectiveDLLInjection.h
+++ b/common/ReflectiveDLLInjection.h
@@ -25,7 +25,10 @@
 // OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //===============================================================================================//
-#pragma clang optimize off
+// #ifdef ARKARI_OBFUSCATOR
+// #pragma clang optimize off
+// #pragma optimize("", off)
+// #endif
 #ifndef _REFLECTIVEDLLINJECTION_REFLECTIVEDLLINJECTION_H
 #define _REFLECTIVEDLLINJECTION_REFLECTIVEDLLINJECTION_H
 //===============================================================================================//

--- a/dll/src/DirectSyscall.c
+++ b/dll/src/DirectSyscall.c
@@ -20,7 +20,7 @@
 // #endif
 
 #pragma warning(disable : 4100) // Unreferenced parameter 'pSyscall' is intentionally handled by assembly.
-COMPILER_OPTIONS NTSTATUS SyscallStub(Syscall *pSyscall, ULONG_PTR **lpArgs, DWORD dwNumberOfArgs)
+COMPILER_OPTIONS NTSTATUS SyscallStub(Syscall *pSyscall, DWORD dwNumberOfArgs, ULONG_PTR lpArgs)
 {
 	return DoSyscall(pSyscall->pStub, pSyscall->dwSyscallNr, lpArgs, dwNumberOfArgs);
 }
@@ -29,23 +29,23 @@ COMPILER_OPTIONS NTSTATUS SyscallStub(Syscall *pSyscall, ULONG_PTR **lpArgs, DWO
 
 COMPILER_OPTIONS NTSTATUS rdiNtAllocateVirtualMemory(Syscall *pSyscall, HANDLE hProcess, PVOID *pBaseAddress, ULONG_PTR pZeroBits, PSIZE_T pRegionSize, ULONG ulAllocationType, ULONG ulProtect)
 {
-	ULONG_PTR *lpArgs[] = { (ULONG_PTR *)hProcess, (ULONG_PTR *)pBaseAddress, (ULONG_PTR *)pZeroBits, (ULONG_PTR *)pRegionSize, (ULONG_PTR *)ulAllocationType, (ULONG_PTR *)ulProtect };
-	return SyscallStub(pSyscall, &lpArgs, 6);
+	ULONG lpArgs[] = { (ULONG)hProcess, (ULONG)pBaseAddress, (ULONG)pZeroBits, (ULONG)pRegionSize, (ULONG)ulAllocationType, (ULONG)ulProtect };
+	return SyscallStub(pSyscall, sizeof(lpArgs) / sizeof(ULONG), (ULONG_PTR)&lpArgs);
 }
 COMPILER_OPTIONS NTSTATUS rdiNtProtectVirtualMemory(Syscall *pSyscall, HANDLE hProcess, PVOID *pBaseAddress, PSIZE_T pNumberOfBytesToProtect, ULONG ulNewAccessProtection, PULONG ulOldAccessProtection)
 {
-	ULONG_PTR *lpArgs[] = { (ULONG_PTR *)hProcess, (ULONG_PTR *)pBaseAddress, (ULONG_PTR *)pNumberOfBytesToProtect, (ULONG_PTR *)ulNewAccessProtection, (ULONG_PTR *)ulOldAccessProtection };
-	return SyscallStub(pSyscall, &lpArgs, 5);
+	ULONG lpArgs[] = { (ULONG)hProcess, (ULONG)pBaseAddress, (ULONG)pNumberOfBytesToProtect, (ULONG)ulNewAccessProtection, (ULONG)ulOldAccessProtection };
+	return SyscallStub(pSyscall, sizeof(lpArgs) / sizeof(ULONG), (ULONG_PTR)&lpArgs);
 }
 COMPILER_OPTIONS NTSTATUS rdiNtFlushInstructionCache(Syscall *pSyscall, HANDLE hProcess, PVOID *pBaseAddress, SIZE_T FlushSize)
 {
-	ULONG_PTR *lpArgs[] = { (ULONG_PTR *)hProcess, (ULONG_PTR *)pBaseAddress, (ULONG_PTR *)FlushSize };
-	return SyscallStub(pSyscall, &lpArgs, 3);
+	ULONG lpArgs[] = { (ULONG)hProcess, (ULONG)pBaseAddress, (ULONG)FlushSize };
+	return SyscallStub(pSyscall, sizeof(lpArgs) / sizeof(ULONG), (ULONG_PTR)&lpArgs);
 }
 COMPILER_OPTIONS NTSTATUS rdiNtLockVirtualMemory(Syscall *pSyscall, HANDLE hProcess, PVOID *pBaseAddress, PSIZE_T NumberOfBytesToLock, ULONG MapType)
 {
-	ULONG_PTR *lpArgs[] = { (ULONG_PTR *)hProcess, (ULONG_PTR *)pBaseAddress, (ULONG_PTR *)NumberOfBytesToLock, (ULONG_PTR *)MapType };
-	return SyscallStub(pSyscall, &lpArgs, 4);
+	ULONG lpArgs[] = { (ULONG)hProcess, (ULONG)pBaseAddress, (ULONG)NumberOfBytesToLock, (ULONG)MapType };
+	return SyscallStub(pSyscall, sizeof(lpArgs) / sizeof(ULONG), (ULONG_PTR)&lpArgs);
 }
 
 //===============================================================================================//

--- a/dll/src/DirectSyscall.c
+++ b/dll/src/DirectSyscall.c
@@ -20,7 +20,7 @@
 // #endif
 
 #pragma warning(disable : 4100) // Unreferenced parameter 'pSyscall' is intentionally handled by assembly.
-COMPILER_OPTIONS NTSTATUS SyscallStub(Syscall *pSyscall, DWORD dwNumberOfArgs, ULONG_PTR lpArgs)
+COMPILER_OPTIONS NTSTATUS SyscallStub(Syscall *pSyscall, DWORD dwNumberOfArgs, ULONG_PTR *lpArgs)
 {
 	return DoSyscall(pSyscall->pStub, pSyscall->dwSyscallNr, lpArgs, dwNumberOfArgs);
 }
@@ -29,23 +29,23 @@ COMPILER_OPTIONS NTSTATUS SyscallStub(Syscall *pSyscall, DWORD dwNumberOfArgs, U
 
 COMPILER_OPTIONS NTSTATUS rdiNtAllocateVirtualMemory(Syscall *pSyscall, HANDLE hProcess, PVOID *pBaseAddress, ULONG_PTR pZeroBits, PSIZE_T pRegionSize, ULONG ulAllocationType, ULONG ulProtect)
 {
-	ULONG lpArgs[] = { (ULONG)hProcess, (ULONG)pBaseAddress, (ULONG)pZeroBits, (ULONG)pRegionSize, (ULONG)ulAllocationType, (ULONG)ulProtect };
-	return SyscallStub(pSyscall, sizeof(lpArgs) / sizeof(ULONG), (ULONG_PTR)&lpArgs);
+	ULONG_PTR lpArgs[] = { (ULONG_PTR)hProcess, (ULONG_PTR)pBaseAddress, (ULONG_PTR)pZeroBits, (ULONG_PTR)pRegionSize, (ULONG_PTR)ulAllocationType, (ULONG_PTR)ulProtect };
+	return SyscallStub(pSyscall, sizeof(lpArgs) / sizeof(ULONG), (ULONG_PTR *)&lpArgs);
 }
 COMPILER_OPTIONS NTSTATUS rdiNtProtectVirtualMemory(Syscall *pSyscall, HANDLE hProcess, PVOID *pBaseAddress, PSIZE_T pNumberOfBytesToProtect, ULONG ulNewAccessProtection, PULONG ulOldAccessProtection)
 {
-	ULONG lpArgs[] = { (ULONG)hProcess, (ULONG)pBaseAddress, (ULONG)pNumberOfBytesToProtect, (ULONG)ulNewAccessProtection, (ULONG)ulOldAccessProtection };
-	return SyscallStub(pSyscall, sizeof(lpArgs) / sizeof(ULONG), (ULONG_PTR)&lpArgs);
+	ULONG_PTR lpArgs[] = { (ULONG_PTR)hProcess, (ULONG_PTR)pBaseAddress, (ULONG_PTR)pNumberOfBytesToProtect, (ULONG_PTR)ulNewAccessProtection, (ULONG_PTR)ulOldAccessProtection };
+	return SyscallStub(pSyscall, sizeof(lpArgs) / sizeof(ULONG_PTR), (ULONG_PTR *)&lpArgs);
 }
 COMPILER_OPTIONS NTSTATUS rdiNtFlushInstructionCache(Syscall *pSyscall, HANDLE hProcess, PVOID *pBaseAddress, SIZE_T FlushSize)
 {
-	ULONG lpArgs[] = { (ULONG)hProcess, (ULONG)pBaseAddress, (ULONG)FlushSize };
-	return SyscallStub(pSyscall, sizeof(lpArgs) / sizeof(ULONG), (ULONG_PTR)&lpArgs);
+	ULONG_PTR lpArgs[] = { (ULONG_PTR)hProcess, (ULONG_PTR)pBaseAddress, (ULONG_PTR)FlushSize };
+	return SyscallStub(pSyscall, sizeof(lpArgs) / sizeof(ULONG_PTR), (ULONG_PTR *)&lpArgs);
 }
 COMPILER_OPTIONS NTSTATUS rdiNtLockVirtualMemory(Syscall *pSyscall, HANDLE hProcess, PVOID *pBaseAddress, PSIZE_T NumberOfBytesToLock, ULONG MapType)
 {
-	ULONG lpArgs[] = { (ULONG)hProcess, (ULONG)pBaseAddress, (ULONG)NumberOfBytesToLock, (ULONG)MapType };
-	return SyscallStub(pSyscall, sizeof(lpArgs) / sizeof(ULONG), (ULONG_PTR)&lpArgs);
+	ULONG_PTR lpArgs[] = { (ULONG_PTR)hProcess, (ULONG_PTR)pBaseAddress, (ULONG_PTR)NumberOfBytesToLock, (ULONG_PTR)MapType };
+	return SyscallStub(pSyscall, sizeof(lpArgs) / sizeof(ULONG_PTR), (ULONG_PTR *)&lpArgs);
 }
 
 //===============================================================================================//

--- a/dll/src/DirectSyscall.c
+++ b/dll/src/DirectSyscall.c
@@ -9,33 +9,40 @@
 //===============================================================================================//
 
 #pragma optimize("g", off)
+#ifdef __MINGW32__ 
 #pragma GCC push_options
 #pragma GCC optimize("O0")
+#endif
+// #ifdef ARKARI_OBFUSCATOR
+// #pragma GCC push_options
+// #pragma GCC optimize("O0")
+// #pragma clang optimize off
+// #endif
 
 #pragma warning(disable : 4100) // Unreferenced parameter 'pSyscall' is intentionally handled by assembly.
-NO_OBF NTSTATUS SyscallStub(Syscall *pSyscall, ULONG_PTR **lpArgs, DWORD dwNumberOfArgs)
+COMPILER_OPTIONS NTSTATUS SyscallStub(Syscall *pSyscall, ULONG_PTR **lpArgs, DWORD dwNumberOfArgs)
 {
 	return DoSyscall(pSyscall->pStub, pSyscall->dwSyscallNr, lpArgs, dwNumberOfArgs);
 }
 
 #pragma warning(default : 4100)
 
-NO_OBF NTSTATUS rdiNtAllocateVirtualMemory(Syscall *pSyscall, HANDLE hProcess, PVOID *pBaseAddress, ULONG_PTR pZeroBits, PSIZE_T pRegionSize, ULONG ulAllocationType, ULONG ulProtect)
+COMPILER_OPTIONS NTSTATUS rdiNtAllocateVirtualMemory(Syscall *pSyscall, HANDLE hProcess, PVOID *pBaseAddress, ULONG_PTR pZeroBits, PSIZE_T pRegionSize, ULONG ulAllocationType, ULONG ulProtect)
 {
 	ULONG_PTR *lpArgs[] = { (ULONG_PTR *)hProcess, (ULONG_PTR *)pBaseAddress, (ULONG_PTR *)pZeroBits, (ULONG_PTR *)pRegionSize, (ULONG_PTR *)ulAllocationType, (ULONG_PTR *)ulProtect };
 	return SyscallStub(pSyscall, &lpArgs, 6);
 }
-NO_OBF NTSTATUS rdiNtProtectVirtualMemory(Syscall *pSyscall, HANDLE hProcess, PVOID *pBaseAddress, PSIZE_T pNumberOfBytesToProtect, ULONG ulNewAccessProtection, PULONG ulOldAccessProtection)
+COMPILER_OPTIONS NTSTATUS rdiNtProtectVirtualMemory(Syscall *pSyscall, HANDLE hProcess, PVOID *pBaseAddress, PSIZE_T pNumberOfBytesToProtect, ULONG ulNewAccessProtection, PULONG ulOldAccessProtection)
 {
 	ULONG_PTR *lpArgs[] = { (ULONG_PTR *)hProcess, (ULONG_PTR *)pBaseAddress, (ULONG_PTR *)pNumberOfBytesToProtect, (ULONG_PTR *)ulNewAccessProtection, (ULONG_PTR *)ulOldAccessProtection };
 	return SyscallStub(pSyscall, &lpArgs, 5);
 }
-NO_OBF NTSTATUS rdiNtFlushInstructionCache(Syscall *pSyscall, HANDLE hProcess, PVOID *pBaseAddress, SIZE_T FlushSize)
+COMPILER_OPTIONS NTSTATUS rdiNtFlushInstructionCache(Syscall *pSyscall, HANDLE hProcess, PVOID *pBaseAddress, SIZE_T FlushSize)
 {
 	ULONG_PTR *lpArgs[] = { (ULONG_PTR *)hProcess, (ULONG_PTR *)pBaseAddress, (ULONG_PTR *)FlushSize };
 	return SyscallStub(pSyscall, &lpArgs, 3);
 }
-NO_OBF NTSTATUS rdiNtLockVirtualMemory(Syscall *pSyscall, HANDLE hProcess, PVOID *pBaseAddress, PSIZE_T NumberOfBytesToLock, ULONG MapType)
+COMPILER_OPTIONS NTSTATUS rdiNtLockVirtualMemory(Syscall *pSyscall, HANDLE hProcess, PVOID *pBaseAddress, PSIZE_T NumberOfBytesToLock, ULONG MapType)
 {
 	ULONG_PTR *lpArgs[] = { (ULONG_PTR *)hProcess, (ULONG_PTR *)pBaseAddress, (ULONG_PTR *)NumberOfBytesToLock, (ULONG_PTR *)MapType };
 	return SyscallStub(pSyscall, &lpArgs, 4);
@@ -59,7 +66,7 @@ NO_OBF NTSTATUS rdiNtLockVirtualMemory(Syscall *pSyscall, HANDLE hProcess, PVOID
 //     exact opcode of a given function's 'svc' instruction, verifying its integrity.
 //     The "stub" we execute is the function address itself.
 //===============================================================================================//
-NO_OBF BOOL getSyscalls(PVOID pNtdllBase, Syscall *Syscalls[], DWORD dwSyscallSize)
+COMPILER_OPTIONS BOOL getSyscalls(PVOID pNtdllBase, Syscall *Syscalls[], DWORD dwSyscallSize)
 {
 	PIMAGE_DOS_HEADER pDosHdr = (PIMAGE_DOS_HEADER)pNtdllBase;
 	PIMAGE_NT_HEADERS pNtHdrs = (PIMAGE_NT_HEADERS)((PBYTE)pNtdllBase + pDosHdr->e_lfanew);

--- a/dll/src/DirectSyscall.c
+++ b/dll/src/DirectSyscall.c
@@ -9,42 +9,37 @@
 //===============================================================================================//
 
 #pragma optimize("g", off)
-#ifdef __MINGW32__
 #pragma GCC push_options
 #pragma GCC optimize("O0")
-#endif
 
 #pragma warning(disable : 4100) // Unreferenced parameter 'pSyscall' is intentionally handled by assembly.
-NTSTATUS SyscallStub(Syscall *pSyscall, ...)
+NO_OBF NTSTATUS SyscallStub(Syscall *pSyscall, ULONG_PTR **lpArgs, DWORD dwNumberOfArgs)
 {
-	// This function acts as a bridge to the assembly trampoline. The first argument,
-	// pSyscall, is passed in the first argument register (rcx/x0/stack), and all
-	// subsequent arguments follow the standard C calling convention.
-	return DoSyscall();
+	return DoSyscall(pSyscall->pStub, pSyscall->dwSyscallNr, lpArgs, dwNumberOfArgs);
 }
+
 #pragma warning(default : 4100)
 
-NTSTATUS rdiNtAllocateVirtualMemory(Syscall *pSyscall, HANDLE hProcess, PVOID *pBaseAddress, ULONG_PTR pZeroBits, PSIZE_T pRegionSize, ULONG ulAllocationType, ULONG ulProtect)
+NO_OBF NTSTATUS rdiNtAllocateVirtualMemory(Syscall *pSyscall, HANDLE hProcess, PVOID *pBaseAddress, ULONG_PTR pZeroBits, PSIZE_T pRegionSize, ULONG ulAllocationType, ULONG ulProtect)
 {
-	return SyscallStub(pSyscall, hProcess, pBaseAddress, pZeroBits, pRegionSize, ulAllocationType, ulProtect);
+	ULONG_PTR *lpArgs[] = { (ULONG_PTR *)hProcess, (ULONG_PTR *)pBaseAddress, (ULONG_PTR *)pZeroBits, (ULONG_PTR *)pRegionSize, (ULONG_PTR *)ulAllocationType, (ULONG_PTR *)ulProtect };
+	return SyscallStub(pSyscall, &lpArgs, 6);
 }
-NTSTATUS rdiNtProtectVirtualMemory(Syscall *pSyscall, HANDLE hProcess, PVOID *pBaseAddress, PSIZE_T pNumberOfBytesToProtect, ULONG ulNewAccessProtection, PULONG ulOldAccessProtection)
+NO_OBF NTSTATUS rdiNtProtectVirtualMemory(Syscall *pSyscall, HANDLE hProcess, PVOID *pBaseAddress, PSIZE_T pNumberOfBytesToProtect, ULONG ulNewAccessProtection, PULONG ulOldAccessProtection)
 {
-	return SyscallStub(pSyscall, hProcess, pBaseAddress, pNumberOfBytesToProtect, ulNewAccessProtection, ulOldAccessProtection);
+	ULONG_PTR *lpArgs[] = { (ULONG_PTR *)hProcess, (ULONG_PTR *)pBaseAddress, (ULONG_PTR *)pNumberOfBytesToProtect, (ULONG_PTR *)ulNewAccessProtection, (ULONG_PTR *)ulOldAccessProtection };
+	return SyscallStub(pSyscall, &lpArgs, 5);
 }
-NTSTATUS rdiNtFlushInstructionCache(Syscall *pSyscall, HANDLE hProcess, PVOID *pBaseAddress, SIZE_T FlushSize)
+NO_OBF NTSTATUS rdiNtFlushInstructionCache(Syscall *pSyscall, HANDLE hProcess, PVOID *pBaseAddress, SIZE_T FlushSize)
 {
-	return SyscallStub(pSyscall, hProcess, pBaseAddress, FlushSize);
+	ULONG_PTR *lpArgs[] = { (ULONG_PTR *)hProcess, (ULONG_PTR *)pBaseAddress, (ULONG_PTR *)FlushSize };
+	return SyscallStub(pSyscall, &lpArgs, 3);
 }
-NTSTATUS rdiNtLockVirtualMemory(Syscall *pSyscall, HANDLE hProcess, PVOID *pBaseAddress, PSIZE_T NumberOfBytesToLock, ULONG MapType)
+NO_OBF NTSTATUS rdiNtLockVirtualMemory(Syscall *pSyscall, HANDLE hProcess, PVOID *pBaseAddress, PSIZE_T NumberOfBytesToLock, ULONG MapType)
 {
-	return SyscallStub(pSyscall, hProcess, pBaseAddress, NumberOfBytesToLock, MapType);
+	ULONG_PTR *lpArgs[] = { (ULONG_PTR *)hProcess, (ULONG_PTR *)pBaseAddress, (ULONG_PTR *)NumberOfBytesToLock, (ULONG_PTR *)MapType };
+	return SyscallStub(pSyscall, &lpArgs, 4);
 }
-
-#ifdef __MINGW32__
-#pragma GCC pop_options
-#endif
-#pragma optimize("g", on)
 
 //===============================================================================================//
 // This function resolves the necessary information for direct syscall invocation. It uses
@@ -64,7 +59,7 @@ NTSTATUS rdiNtLockVirtualMemory(Syscall *pSyscall, HANDLE hProcess, PVOID *pBase
 //     exact opcode of a given function's 'svc' instruction, verifying its integrity.
 //     The "stub" we execute is the function address itself.
 //===============================================================================================//
-BOOL getSyscalls(PVOID pNtdllBase, Syscall *Syscalls[], DWORD dwSyscallSize)
+NO_OBF BOOL getSyscalls(PVOID pNtdllBase, Syscall *Syscalls[], DWORD dwSyscallSize)
 {
 	PIMAGE_DOS_HEADER pDosHdr = (PIMAGE_DOS_HEADER)pNtdllBase;
 	PIMAGE_NT_HEADERS pNtHdrs = (PIMAGE_NT_HEADERS)((PBYTE)pNtdllBase + pDosHdr->e_lfanew);

--- a/dll/src/DirectSyscall.c
+++ b/dll/src/DirectSyscall.c
@@ -9,7 +9,7 @@
 //===============================================================================================//
 
 #pragma optimize("g", off)
-#ifdef __MINGW32__ 
+#ifdef __MINGW32__
 #pragma GCC push_options
 #pragma GCC optimize("O0")
 #endif

--- a/dll/src/DirectSyscall.c
+++ b/dll/src/DirectSyscall.c
@@ -30,7 +30,7 @@ COMPILER_OPTIONS NTSTATUS SyscallStub(Syscall *pSyscall, DWORD dwNumberOfArgs, U
 COMPILER_OPTIONS NTSTATUS rdiNtAllocateVirtualMemory(Syscall *pSyscall, HANDLE hProcess, PVOID *pBaseAddress, ULONG_PTR pZeroBits, PSIZE_T pRegionSize, ULONG ulAllocationType, ULONG ulProtect)
 {
 	ULONG_PTR lpArgs[] = { (ULONG_PTR)hProcess, (ULONG_PTR)pBaseAddress, (ULONG_PTR)pZeroBits, (ULONG_PTR)pRegionSize, (ULONG_PTR)ulAllocationType, (ULONG_PTR)ulProtect };
-	return SyscallStub(pSyscall, sizeof(lpArgs) / sizeof(ULONG), (ULONG_PTR *)&lpArgs);
+	return SyscallStub(pSyscall, sizeof(lpArgs) / sizeof(ULONG_PTR), (ULONG_PTR *)&lpArgs);
 }
 COMPILER_OPTIONS NTSTATUS rdiNtProtectVirtualMemory(Syscall *pSyscall, HANDLE hProcess, PVOID *pBaseAddress, PSIZE_T pNumberOfBytesToProtect, ULONG ulNewAccessProtection, PULONG ulOldAccessProtection)
 {

--- a/dll/src/DirectSyscall.h
+++ b/dll/src/DirectSyscall.h
@@ -13,7 +13,7 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <intrin.h>
-
+#define NO_OBF __attribute((__annotate__(("-indbr -icall -indgv -cse -fla"))))
 #ifdef _WIN64
 #define SYS_STUB_SIZE 32
 #else
@@ -200,13 +200,13 @@ typedef struct __PEB // 65 elements, 0x210 bytes
 
 //===============================================================================================//
 
-BOOL getSyscalls(PVOID pNtdllBase, Syscall* Syscalls[], DWORD dwNumberOfSyscalls);
-extern NTSTATUS DoSyscall(VOID);
+NO_OBF BOOL getSyscalls(PVOID pNtdllBase, Syscall* Syscalls[], DWORD dwNumberOfSyscalls);
+extern NO_OBF NTSTATUS DoSyscall(VOID *fn, DWORD dwSyscallNr, ULONG **lpArgs, DWORD dwNumberOfArgs);
 
 //
 // Native API functions
 //
-NTSTATUS rdiNtAllocateVirtualMemory(Syscall* pSyscall, HANDLE hProcess, PVOID* pBaseAddress, ULONG_PTR pZeroBits, PSIZE_T pRegionSize, ULONG ulAllocationType, ULONG ulProtect);
-NTSTATUS rdiNtProtectVirtualMemory(Syscall* pSyscall, HANDLE hProcess, PVOID* pBaseAddress, PSIZE_T pNumberOfBytesToProtect, ULONG ulNewAccessProtection, PULONG ulOldAccessProtection);
-NTSTATUS rdiNtFlushInstructionCache(Syscall* pSyscall, HANDLE hProcess, PVOID* pBaseAddress, SIZE_T FlushSize);
-NTSTATUS rdiNtLockVirtualMemory(Syscall* pSyscall, HANDLE hProcess, PVOID* pBaseAddress, PSIZE_T NumberOfBytesToLock, ULONG MapType);
+NO_OBF NTSTATUS rdiNtAllocateVirtualMemory(Syscall* pSyscall, HANDLE hProcess, PVOID* pBaseAddress, ULONG_PTR pZeroBits, PSIZE_T pRegionSize, ULONG ulAllocationType, ULONG ulProtect);
+NO_OBF NTSTATUS rdiNtProtectVirtualMemory(Syscall* pSyscall, HANDLE hProcess, PVOID* pBaseAddress, PSIZE_T pNumberOfBytesToProtect, ULONG ulNewAccessProtection, PULONG ulOldAccessProtection);
+NO_OBF NTSTATUS rdiNtFlushInstructionCache(Syscall* pSyscall, HANDLE hProcess, PVOID* pBaseAddress, SIZE_T FlushSize);
+NO_OBF NTSTATUS rdiNtLockVirtualMemory(Syscall* pSyscall, HANDLE hProcess, PVOID* pBaseAddress, PSIZE_T NumberOfBytesToLock, ULONG MapType);

--- a/dll/src/DirectSyscall.h
+++ b/dll/src/DirectSyscall.h
@@ -207,7 +207,7 @@ typedef struct __PEB // 65 elements, 0x210 bytes
 //===============================================================================================//
 
 COMPILER_OPTIONS BOOL getSyscalls(PVOID pNtdllBase, Syscall* Syscalls[], DWORD dwNumberOfSyscalls);
-extern COMPILER_OPTIONS NTSTATUS DoSyscall(VOID *fn, DWORD dwSyscallNr, ULONG_PTR lpArgs, DWORD dwNumberOfArgs);
+extern COMPILER_OPTIONS NTSTATUS DoSyscall(VOID *fn, DWORD dwSyscallNr, ULONG_PTR *lpArgs, DWORD dwNumberOfArgs);
 
 //
 // Native API functions

--- a/dll/src/DirectSyscall.h
+++ b/dll/src/DirectSyscall.h
@@ -13,7 +13,13 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <intrin.h>
-#define NO_OBF __attribute((__annotate__(("-indbr -icall -indgv -cse -fla"))))
+
+#ifdef ARKARI_OBFUSCATOR
+#define COMPILER_OPTIONS __attribute((__annotate__(("-indbr -icall -indgv -cse -fla"))))
+#else
+#define COMPILER_OPTIONS
+#endif
+
 #ifdef _WIN64
 #define SYS_STUB_SIZE 32
 #else
@@ -200,13 +206,13 @@ typedef struct __PEB // 65 elements, 0x210 bytes
 
 //===============================================================================================//
 
-NO_OBF BOOL getSyscalls(PVOID pNtdllBase, Syscall* Syscalls[], DWORD dwNumberOfSyscalls);
-extern NO_OBF NTSTATUS DoSyscall(VOID *fn, DWORD dwSyscallNr, ULONG **lpArgs, DWORD dwNumberOfArgs);
+COMPILER_OPTIONS BOOL getSyscalls(PVOID pNtdllBase, Syscall* Syscalls[], DWORD dwNumberOfSyscalls);
+extern COMPILER_OPTIONS NTSTATUS DoSyscall(VOID *fn, DWORD dwSyscallNr, ULONG **lpArgs, DWORD dwNumberOfArgs);
 
 //
 // Native API functions
 //
-NO_OBF NTSTATUS rdiNtAllocateVirtualMemory(Syscall* pSyscall, HANDLE hProcess, PVOID* pBaseAddress, ULONG_PTR pZeroBits, PSIZE_T pRegionSize, ULONG ulAllocationType, ULONG ulProtect);
-NO_OBF NTSTATUS rdiNtProtectVirtualMemory(Syscall* pSyscall, HANDLE hProcess, PVOID* pBaseAddress, PSIZE_T pNumberOfBytesToProtect, ULONG ulNewAccessProtection, PULONG ulOldAccessProtection);
-NO_OBF NTSTATUS rdiNtFlushInstructionCache(Syscall* pSyscall, HANDLE hProcess, PVOID* pBaseAddress, SIZE_T FlushSize);
-NO_OBF NTSTATUS rdiNtLockVirtualMemory(Syscall* pSyscall, HANDLE hProcess, PVOID* pBaseAddress, PSIZE_T NumberOfBytesToLock, ULONG MapType);
+COMPILER_OPTIONS NTSTATUS rdiNtAllocateVirtualMemory(Syscall* pSyscall, HANDLE hProcess, PVOID* pBaseAddress, ULONG_PTR pZeroBits, PSIZE_T pRegionSize, ULONG ulAllocationType, ULONG ulProtect);
+COMPILER_OPTIONS NTSTATUS rdiNtProtectVirtualMemory(Syscall* pSyscall, HANDLE hProcess, PVOID* pBaseAddress, PSIZE_T pNumberOfBytesToProtect, ULONG ulNewAccessProtection, PULONG ulOldAccessProtection);
+COMPILER_OPTIONS NTSTATUS rdiNtFlushInstructionCache(Syscall* pSyscall, HANDLE hProcess, PVOID* pBaseAddress, SIZE_T FlushSize);
+COMPILER_OPTIONS NTSTATUS rdiNtLockVirtualMemory(Syscall* pSyscall, HANDLE hProcess, PVOID* pBaseAddress, PSIZE_T NumberOfBytesToLock, ULONG MapType);

--- a/dll/src/DirectSyscall.h
+++ b/dll/src/DirectSyscall.h
@@ -207,7 +207,7 @@ typedef struct __PEB // 65 elements, 0x210 bytes
 //===============================================================================================//
 
 COMPILER_OPTIONS BOOL getSyscalls(PVOID pNtdllBase, Syscall* Syscalls[], DWORD dwNumberOfSyscalls);
-extern COMPILER_OPTIONS NTSTATUS DoSyscall(VOID *fn, DWORD dwSyscallNr, ULONG **lpArgs, DWORD dwNumberOfArgs);
+extern COMPILER_OPTIONS NTSTATUS DoSyscall(VOID *fn, DWORD dwSyscallNr, ULONG_PTR lpArgs, DWORD dwNumberOfArgs);
 
 //
 // Native API functions

--- a/dll/src/GateTrampoline32.asm
+++ b/dll/src/GateTrampoline32.asm
@@ -1,3 +1,15 @@
+;
+; GateTrampoline32.asm
+;
+; DoSyscall function implementation for 32-bit Windows to perform system calls with arguments passed as an array.
+;  NTSTATUS DoSyscall(VOID *fn, DWORD dwSyscallNr, ULONG_PTR *lpArgs, DWORD dwNumberOfArgs);
+;
+; Authors:
+;  Christophe De La Fuente <christophe_delafuente[at]rapid7[dot]com>  - Original implementation
+;  Muzaffer Umut ŞAHİN <mailatmayinlutfen[at]gmail[dot]com>           - Argument as array modification
+;  Diego Ledda <diego_ledda[at]rapid7[dot]com>                        - Argument as array porting and cleanup
+;
+
 .686P
 .model flat, C
 

--- a/dll/src/GateTrampoline32.asm
+++ b/dll/src/GateTrampoline32.asm
@@ -6,43 +6,32 @@
 OPTION LANGUAGE: C
 DoSyscall PROC
 
-  mov eax, [esp+0Ch]               ; get the pointer to Syscall
-  mov eax, [eax+4]                 ; get the number of arguments
-  lea eax, [4*eax]                 ; calculate the number of bytes needed to store the arguments
-  sub esp, eax                     ; make room on the stack for the arguments
-
-  push edi                         ; store edi on stack to be able to restore it later
   push ebx                         ; store ebx on stack to be able to restore it later
-  push ecx                         ; store ecx on stack to be able to restore it later
-
-  mov edi, [esp+0Ch+eax]           ; save the return address
-  mov ebx, [esp+18h+eax]           ; get the pointer to the Syscall structure
-  mov ecx, [ebx+4]                 ; get the number of arguments (.dwNumberOfArgs)
-
-  mov [esp+0Ch], edi               ; place the return address on the stack
-
-  test ecx, ecx                    ; check if we have arguments
-  jz _end                          ; we don't, jump directly to _end
-  xor eax, eax                     ; zero out eax, this will be the index
-  lea edi, [esp+0Ch+4*ecx]         ; set the base pointer that will be used in loop
-
-_loop:
-  mov edx, [edi+10h+4*eax]         ; get the argument
-  mov [esp+10h+4*eax], edx         ; store it to the correct location
-  inc eax                          ; increment the index
-  cmp eax, ecx                     ; check if we have more arguments to process
-  jl _loop                         ; loop back to process the next argument
-
-_end:
-  mov eax, ebx                     ; save the pointer to the Syscall structure to eax
-
-  pop ecx                          ; restore ecx
-  pop ebx                          ; restore ebx
-  pop edi                          ; restore edi
-
-  push [eax+0Ch]                   ; push the syscall stub on the stack
-  mov eax, [eax+8]                 ; store the syscall number to eax
-  ret                              ; return to the stub
+  push esi                         ; store esi on stack to be able to restore it later
+  push edi                         ; store edi on stack to be able to restore it later
+  push ebp                         ; store ebp on stack to be able to restore it later
+  mov ebp, esp                     ; save the current stack pointer in ebp
+  mov edi, [ebp + 14h]             ; move the function pointer (first argument) into edi
+  mov esi, [ebp + 18h]             ; move the syscall number (second argument) into esi
+  mov ebx, [ebp + 1Ch]             ; move the pointer to the arguments (third argument) into ebx
+  mov ecx, [ebp + 20h]             ; move the number of arguments (fourth argument) into ecx
+  test ecx, ecx                    ; if no arguments, jump to _no_args
+  je _no_args
+  lea ebx, [ebx + ecx * 4 - 4]    ; point ebx to the last argument
+_push_args:
+  push [ebx]                       ; push the argument onto the stack
+  sub ebx, 4
+  dec ecx
+  jnz _push_args                   ; repeat until all arguments are pushed onto the stack
+_no_args:
+  mov eax, esi                     ; move the syscall number into eax for the syscall
+  call edi                         ; call the syscall function pointer in edi
+  mov esp, ebp                     ; restore the original stack pointer from ebp
+  pop ebp                          ; restore ebp from stack
+  pop edi                          ; restore edi from stack
+  pop esi                          ; restore esi from stack
+  pop ebx                          ; restore ebx from stack
+  ret
 
 DoSyscall ENDP
 

--- a/dll/src/GateTrampoline32.s
+++ b/dll/src/GateTrampoline32.s
@@ -1,3 +1,14 @@
+;
+; GateTrampoline32.s
+;
+; DoSyscall function implementation for 32-bit Windows to perform system calls with arguments passed as an array.
+;  NTSTATUS DoSyscall(VOID *fn, DWORD dwSyscallNr, ULONG_PTR *lpArgs, DWORD dwNumberOfArgs);
+;
+; Authors:
+;  Christophe De La Fuente <christophe_delafuente[at]rapid7[dot]com>  - Original implementation
+;  Muzaffer Umut ŞAHİN <mailatmayinlutfen[at]gmail[dot]com>           - Argument as array modification
+;  Diego Ledda <diego_ledda[at]rapid7[dot]com>                        - Argument as array porting and cleanup
+;
     .intel_syntax noprefix
 
     .global _DoSyscall

--- a/dll/src/GateTrampoline32.s
+++ b/dll/src/GateTrampoline32.s
@@ -1,14 +1,14 @@
-;
-; GateTrampoline32.s
-;
-; DoSyscall function implementation for 32-bit Windows to perform system calls with arguments passed as an array.
-;  NTSTATUS DoSyscall(VOID *fn, DWORD dwSyscallNr, ULONG_PTR *lpArgs, DWORD dwNumberOfArgs);
-;
-; Authors:
-;  Christophe De La Fuente <christophe_delafuente[at]rapid7[dot]com>  - Original implementation
-;  Muzaffer Umut ŞAHİN <mailatmayinlutfen[at]gmail[dot]com>           - Argument as array modification
-;  Diego Ledda <diego_ledda[at]rapid7[dot]com>                        - Argument as array porting and cleanup
-;
+#
+# GateTrampoline32.s
+#
+# DoSyscall function implementation for 32-bit Windows to perform system calls with arguments passed as an array.
+#  NTSTATUS DoSyscall(VOID *fn, DWORD dwSyscallNr, ULONG_PTR *lpArgs, DWORD dwNumberOfArgs);
+#
+# Authors:
+#  Christophe De La Fuente <christophe_delafuente[at]rapid7[dot]com>  - Original implementation
+#  Muzaffer Umut ŞAHİN <mailatmayinlutfen[at]gmail[dot]com>           - Argument as array modification
+#  Diego Ledda <diego_ledda[at]rapid7[dot]com>                        - Argument as array porting and cleanup
+#
     .intel_syntax noprefix
 
     .global _DoSyscall

--- a/dll/src/GateTrampoline32.s
+++ b/dll/src/GateTrampoline32.s
@@ -4,42 +4,30 @@
 
     .text
 _DoSyscall:
-
-  mov eax, [esp+0x14]              # get the pointer to Syscall
-  mov eax, [eax+4]                 # get the number of arguments
-  lea eax, [4*eax]                 # calculate the number of bytes needed to store the arguments
-  sub esp, eax                     # make room on the stack for the arguments
-
-  push edi                         # store edi on stack to be able to restore it later
-  push ebx                         # store ebx on stack to be able to restore it later
-  push ecx                         # store ecx on stack to be able to restore it later
-
-  mov edi, [esp+0x0C+eax]          # save the return address
-  mov ebx, [esp+0x20+eax]          # get the pointer to the Syscall structure
-  mov ecx, [ebx+4]                 # get the number of arguments (.dwNumberOfArgs)
-
-  mov [esp+0x0C], edi              # place the return address on the stack
-
-  test ecx, ecx                    # check if we have arguments
-  jz _end                          # we don't, jump directly to _end
-  xor eax, eax                     # zero out eax, this will be the index
-  lea edi, [esp+0x0C+4*ecx]        # set the base pointer that will be used in loop
-
-_loop:
-  mov edx, [edi+0x18+4*eax]        # get the argument
-  mov [esp+0x10+4*eax], edx        # store it to the correct location
-  inc eax                          # increment the index
-  cmp eax, ecx                     # check if we have more arguments to process
-  jl _loop                         # loop back to process the next argument
-
-_end:
-  mov eax, ebx                     # save the pointer to the Syscall structure to eax
-
-  pop ecx                          # restore ecx
-  pop ebx                          # restore ebx
-  pop edi                          # restore edi
-
-  push [eax+0x0C]                  # push the syscall stub on the stack
-  mov eax, [eax+8]                 # store the syscall number to eax
-  ret                              # return to the stub
+  push ebx                     # store ebx on stack to be able to restore it later
+  push esi                     # store esi on stack to be able to restore it later
+  push edi                     # store edi on stack to be able to restore it later
+  push ebp                     # store ebp on stack to be able to restore it later
+  mov ebp, esp                 # save the current stack pointer in ebp
+  mov edi, [ebp + 0x14]        # move the function pointer (first argument) into edi
+  mov esi, [ebp + 0x18]        # move the syscall number (second argument) into esi
+  mov ebx, [ebp + 0x1C]        # move the pointer to the arguments (third argument) into ebx
+  mov ecx, [ebp + 0x20]        # move the number of arguments (fourth argument) into ecx
+  test ecx, ecx                # if no arguments, jump to _no_args
+  je _no_args
+  lea ebx, [ebx + ecx * 4 - 4] # point ebx to the last argument
+_push_args:
+  push [ebx]                   # push the argument onto the stack
+  sub ebx, 4
+  dec ecx
+  jnz _push_args               # repeat until all arguments are pushed onto the stack
+_no_args:
+  mov eax, esi                 # move the syscall number into eax for the syscall
+  call edi                     # call the syscall function pointer in edi
+  mov esp, ebp                 # restore the original stack pointer from ebp
+  pop ebp                      # restore ebp from stack
+  pop edi                      # restore edi from stack
+  pop esi                      # restore esi from stack
+  pop ebx                      # restore ebx from stack
+  ret
 

--- a/dll/src/GateTrampoline64.asm
+++ b/dll/src/GateTrampoline64.asm
@@ -1,3 +1,14 @@
+;
+; GateTrampoline64.asm
+;
+; DoSyscall function implementation for 64-bit Windows to perform system calls with arguments passed as an array.
+;  NTSTATUS DoSyscall(VOID *fn, DWORD dwSyscallNr, ULONG_PTR *lpArgs, DWORD dwNumberOfArgs);
+;
+; Authors:
+;  Christophe De La Fuente <christophe_delafuente[at]rapid7[dot]com>  - Original implementation
+;  Muzaffer Umut ŞAHİN <mailatmayinlutfen[at]gmail[dot]com>           - Argument as array modification
+;  Diego Ledda <diego_ledda[at]rapid7[dot]com>                        - Argument as array porting and cleanup
+;
 .code
 
 DoSyscall Proc

--- a/dll/src/GateTrampoline64.asm
+++ b/dll/src/GateTrampoline64.asm
@@ -5,42 +5,58 @@ DoSyscall Proc
   push r11                     ; store r11 on stack to be able to restore it later
   push r12                     ; store r12 on stack to be able to restore it later
   push r13                     ; store r13 on stack to be able to restore it later
-
-  add rsp, 40h                 ; restore the stack pointer to the previous stack frame
-  mov r11, [rsp+10h]           ; get the pointer to the Syscall structure that has been stored in the shadow space
-
-  mov r10, [r11+10h]           ; store the syscall stub in r10. Note that the `.pStub` field is padded with 4 null bytes on x64.
-  mov [rsp], r10               ; place the stub address on the stack, which will be used as return address
-
-  mov rcx, rdx                 ; Arg1 is the pointer to the Syscall structure and we don't need it.
-  mov rdx, r8                  ;   We need to shift all the arguments to have the correct arguments for the syscall.
-  mov r8, r9                   ;   This meens, rdx move to rcx, r8 to rdx, r9 to r8 and first argument on the stack
-  mov r9, [rsp+30h]            ;   to r9.
-
-  ; Now, if the syscall needs more than 4 arguments, we need to deal with arguments stored on the stack
-  xor r12, r12
-  mov r12d, dword ptr [r11+4]  ; store the number of arguments in r12, which will be our counter
-  cmp r12, 4                   ; we already processed 4 arguments, so, check if we have more
-  jle _end                     ; we have less than 4 arguments, jump directly to _end
-  sub r12, 4                   ; adjust the argument counter
-  xor r13, r13                 ; zero out r13, this will be the index
-
-_loop:
-  mov r10, [rsp+38h+8*r13]     ; get the argument
-  mov [rsp+30h+8*r13], r10     ; store it to the correct location
-  inc r13                      ; increment the index
-  cmp r13, r12                 ; check if we have more arguments to process
-  jl _loop                     ; loop back to process the next argument
-
-_end:
-  mov r10, rcx                 ; store the first argument to r10, like the original syscall do
-  xor rax, rax                 ; zero out rax
-  mov eax, dword ptr [r11+8]   ; store the syscall number to eax
-
-  mov r13, [rsp-40h]           ; restore r13
-  mov r12, [rsp-38h]           ; restore r12
-  mov r11, [rsp-30h]           ; restore r11
-  ret                          ; return to the stub
+  push r14                     ; store r14 on stack to be able to restore it later
+  push r15                     ; store r15 on stack to be able to restore it later
+  mov r15, rsp                 ; save the current stack pointer in r15
+  mov r11, rcx                 ; move the function pointer (first argument) into r11
+  mov r14, rdx                 ; move the syscall number (second argument) into r14
+  mov r12, r8                  ; move the pointer to the arguments (third argument) into r12
+  mov r13, r9                  ; move the number of arguments (fourth argument) into r13
+  lea r12, [r12 + r13 * 8 - 8] ; point r12 to the last argument
+  cmp r13, 4
+  jle _setup_registers         ; if there are 4 or fewer arguments, jump to setup_registers
+_setup_stack:
+  push [r12]                   ; push the last argument onto the stack
+  dec r13
+  sub r12, 8
+  cmp r13, 4
+  jne _setup_stack             ; repeat until all arguments are pushed onto the stack
+_setup_registers:
+  cmp r13, 4
+  je _setup_4_registers        ; if there are exactly 4 arguments, jump to setup_4_registers
+  cmp r13, 3
+  je _setup_3_registers        ; if there are exactly 3 arguments, jump
+  cmp r13, 2
+  je _setup_2_registers        ; if there are exactly 2 arguments, jump
+  cmp r13, 1
+  je _setup_1_register         ; if there is exactly 1 argument, jump
+  jmp _no_args                 ; if there are no arguments, jump to no_args
+_setup_4_registers:
+  mov r9, [r12]
+  sub r12, 8
+_setup_3_registers:
+  mov r8, [r12]
+  sub r12, 8
+_setup_2_registers:
+  mov rdx, [r12]
+  sub r12, 8
+_setup_1_register:
+  mov rcx, [r12]               ; move the first argument into rcx for the syscall
+_no_args:
+  push r9                      ; push r9 shadow stack
+  push r8                      ; push r8 shadow stack
+  push rdx                     ; push rdx shadow stack
+  push rcx                     ; push rcx shadow stack
+  mov r10, rcx
+  mov rax, r14                 ; move the syscall number into rax for the syscall
+  call r11                     ; call the syscall function pointer in r11
+  mov rsp, r15                 ; restore the original stack pointer from r15
+  pop r15                      ; restore r15 from stack
+  pop r14                      ; restore r14 from stack
+  pop r13                      ; restore r13 from stack
+  pop r12                      ; restore r12 from stack
+  pop r11                      ; restore r11 from stack
+  ret
 
 DoSyscall ENDP
 

--- a/dll/src/GateTrampoline64.s
+++ b/dll/src/GateTrampoline64.s
@@ -1,3 +1,14 @@
+;
+; GateTrampoline64.s
+;
+; DoSyscall function implementation for 64-bit Windows to perform system calls with arguments passed as an array.
+;  NTSTATUS DoSyscall(VOID *fn, DWORD dwSyscallNr, ULONG_PTR *lpArgs, DWORD dwNumberOfArgs);
+;
+; Authors:
+;  Christophe De La Fuente <christophe_delafuente[at]rapid7[dot]com>  - Original implementation
+;  Muzaffer Umut ŞAHİN <mailatmayinlutfen[at]gmail[dot]com>           - Argument as array modification
+;  Diego Ledda <diego_ledda[at]rapid7[dot]com>                        - Argument as array porting and cleanup
+;
     .intel_syntax noprefix
 
     .global DoSyscall

--- a/dll/src/GateTrampoline64.s
+++ b/dll/src/GateTrampoline64.s
@@ -1,14 +1,14 @@
-;
-; GateTrampoline64.s
-;
-; DoSyscall function implementation for 64-bit Windows to perform system calls with arguments passed as an array.
-;  NTSTATUS DoSyscall(VOID *fn, DWORD dwSyscallNr, ULONG_PTR *lpArgs, DWORD dwNumberOfArgs);
-;
-; Authors:
-;  Christophe De La Fuente <christophe_delafuente[at]rapid7[dot]com>  - Original implementation
-;  Muzaffer Umut ŞAHİN <mailatmayinlutfen[at]gmail[dot]com>           - Argument as array modification
-;  Diego Ledda <diego_ledda[at]rapid7[dot]com>                        - Argument as array porting and cleanup
-;
+#
+# GateTrampoline64.s
+#
+# DoSyscall function implementation for 64-bit Windows to perform system calls with arguments passed as an array.
+#  NTSTATUS DoSyscall(VOID *fn, DWORD dwSyscallNr, ULONG_PTR *lpArgs, DWORD dwNumberOfArgs);
+#
+# Authors:
+#  Christophe De La Fuente <christophe_delafuente[at]rapid7[dot]com>  - Original implementation
+#  Muzaffer Umut ŞAHİN <mailatmayinlutfen[at]gmail[dot]com>           - Argument as array modification
+#  Diego Ledda <diego_ledda[at]rapid7[dot]com>                        - Argument as array porting and cleanup
+#
     .intel_syntax noprefix
 
     .global DoSyscall

--- a/dll/src/GateTrampoline64.s
+++ b/dll/src/GateTrampoline64.s
@@ -4,44 +4,58 @@
 
     .text
 DoSyscall:
-
   push r11                     # store r11 on stack to be able to restore it later
   push r12                     # store r12 on stack to be able to restore it later
   push r13                     # store r13 on stack to be able to restore it later
-
-  add rsp, 0x40                # restore the stack pointer to the previous stack frame
-  mov r11, [rsp+0x10]          # get the pointer to the Syscall structure that has been stored in the shadow space
-
-  mov r10, [r11+0x10]          # store the syscall stub in r10. Note that the `.pStub` field is padded with 4 null bytes on x64.
-  mov [rsp], r10               # place the stub address on the stack, which will be used as return address
-
-  mov rcx, rdx                 # Arg1 is the pointer to the Syscall structure and we don't need it.
-  mov rdx, r8                  #   We need to shift all the arguments to have the correct arguments for the syscall.
-  mov r8, r9                   #   This meens, rdx move to rcx, r8 to rdx, r9 to r8 and first argument on the stack
-  mov r9, [rsp+0x30]           #   to r9.
-
-  # Now, if the syscall needs more than 4 arguments, we need to deal with arguments stored on the stack
-  xor r12, r12
-  mov r12d, dword ptr [r11+4]  # store the number of arguments in r12, which will be our counter
-  cmp r12, 4                   # we already processed 4 arguments, so, check if we have more
-  jle _end                     # we have less than 4 arguments, jump directly to _end
-  sub r12, 4                   # adjust the argument counter
-  xor r13, r13                 # zero out r13, this will be the index
-
-_loop:
-  mov r10, [rsp+0x38+8*r13]    # get the argument
-  mov [rsp+0x30+8*r13], r10    # store it to the correct location
-  inc r13                      # increment the index
-  cmp r13, r12                 # check if we have more arguments to process
-  jl _loop                     # loop back to process the next argument
-
-_end:
-  mov r10, rcx                 # store the first argument to r10, like the original syscall do
-  xor rax, rax                 # zero out rax
-  mov eax, dword ptr [r11+8]   # store the syscall number to eax
-
-  mov r13, [rsp-0x40]          # restore r13
-  mov r12, [rsp-0x38]          # restore r12
-  mov r11, [rsp-0x30]          # restore r11
-  ret                          # return to the stub
-
+  push r14                     # store r14 on stack to be able to restore it later
+  push r15                     # store r15 on stack to be able to restore it later
+  mov r15, rsp                 # save the current stack pointer in r15
+  mov r11, rcx                 # move the function pointer (first argument) into r11
+  mov r14, rdx                 # move the syscall number (second argument) into r14
+  mov r12, r8                  # move the pointer to the arguments (third argument) into r12
+  mov r13, r9                  # move the number of arguments (fourth argument) into r13               # if no arguments, jump to no_args
+  lea r12, [r12 + r13 * 8 - 8] # point r12 to the last argument
+  cmp r13, 4
+  jle _setup_registers        # if there are 4 or fewer arguments, jump to setup_4_registers
+_setup_stack:
+  push [r12]                   # push the last argument onto the stack
+  dec r13
+  sub r12, 8
+  cmp r13, 4
+  jne _setup_stack             # repeat until all arguments are pushed onto the stack
+_setup_registers:
+  cmp r13, 4
+  je _setup_4_registers          # if there are exactly 4 arguments, jump to setup_4_registers
+  cmp r13, 3
+  je _setup_3_registers          # if there are exactly 3 arguments, jump
+  cmp r13, 2
+  je _setup_2_registers          # if there are exactly 2 arguments, jump
+  cmp r13, 1
+  je _setup_1_register           # if there is exactly 1 argument, jump
+  jmp _no_args                   # if there are no arguments, jump to no_args
+_setup_4_registers:
+  mov r9, [r12]
+  sub r12, 8
+_setup_3_registers:
+  mov r8, [r12]
+  sub r12, 8
+_setup_2_registers:
+  mov rdx, [r12]
+  sub r12, 8
+_setup_1_register:
+  mov rcx, [r12]               # move the first argument into rcx for the syscall
+_no_args:
+  push r9                      # push r9 shadow stack
+  push r8                      # push r8 shadow stack
+  push rdx                     # push rdx shadow stack
+  push rcx                     # push rcx shadow stack
+  mov r10, rcx
+  mov rax, r14                 # move the syscall number into rax for the syscall
+  call r11                     # call the syscall function pointer in r11
+  mov rsp, r15                 # restore the original stack pointer from r15
+  pop r15                      # restore r15 from stack
+  pop r14                      # restore r14 from stack
+  pop r13                      # restore r13 from stack
+  pop r12                      # restore r12 from stack
+  pop r11                      # restore r11 from stack
+  ret

--- a/dll/src/GateTrampolineARM64.asm
+++ b/dll/src/GateTrampolineARM64.asm
@@ -5,37 +5,77 @@
     AREA    |.text|, CODE, READONLY, ALIGN=3
     EXPORT  DoSyscall
 
+; DoSyscall(x0=function_pointer, x1=syscall_number, x2=args_pointer, x3=arg_count)
 DoSyscall
-    ; Preserve callee-saved register x19 and the link register x30
-    STP     x19, x30, [sp, #-16]!
+    ; Save callee-saved registers and link register
+    STP     x19, x20, [sp, #-16]!
+    STP     x21, x22, [sp, #-16]!
+    STP     x23, x30, [sp, #-16]!
+    MOV     x19, sp                ; save the current stack pointer in x19
 
-    ; The C wrapper called us. x0 holds the pSyscall pointer.
-    MOV     x19, x0
+    MOV     x20, x0                ; save function pointer in x20
+    MOV     x21, x1                ; save syscall number in x21
+    MOV     x22, x2                ; save args pointer in x22
+    MOV     x23, x3                ; save arg count in x23
 
-    ; Rearrange the C arguments (in x1-x7) into the syscall argument
-    ; registers (x0-x6) as required by the Windows ARM64 syscall ABI.
-    MOV     x0, x1
-    MOV     x1, x2
-    MOV     x2, x3
-    MOV     x3, x4
-    MOV     x4, x5
-    MOV     x5, x6
-    MOV     x6, x7
+    ; Handle stack arguments (arguments beyond the first 8)
+    CMP     x23, #8
+    B.LE    _setup_registers
+    SUB     x9, x23, #8           ; number of stack arguments
+    ADD     x10, x9, #1
+    BIC     x10, x10, #1          ; round up to even for 16-byte stack alignment
+    SUB     sp, sp, x10, LSL #3   ; allocate stack space
+    MOV     x11, #0               ; index = 0
+_copy_stack
+    ADD     x12, x11, #8          ; offset into args array (skip first 8 reg args)
+    LDR     x13, [x22, x12, LSL #3]
+    STR     x13, [sp, x11, LSL #3]
+    ADD     x11, x11, #1
+    CMP     x11, x9
+    B.LT    _copy_stack
 
-    ; The pStub now points directly to the ntdll!Zw* function, which
-    ; contains the necessary 'svc #imm' instruction. We do NOT load
-    ; the syscall number into x8; it's already encoded in the stub.
-    LDR     x10, [x19, #16] ; Load pStub into x10
+_setup_registers
+    ; Load arguments from array into registers x0-x7 based on arg count
+    CMP     x23, #8
+    B.LT    _check7
+    LDR     x7, [x22, #56]
+_check7
+    CMP     x23, #7
+    B.LT    _check6
+    LDR     x6, [x22, #48]
+_check6
+    CMP     x23, #6
+    B.LT    _check5
+    LDR     x5, [x22, #40]
+_check5
+    CMP     x23, #5
+    B.LT    _check4
+    LDR     x4, [x22, #32]
+_check4
+    CMP     x23, #4
+    B.LT    _check3
+    LDR     x3, [x22, #24]
+_check3
+    CMP     x23, #3
+    B.LT    _check2
+    LDR     x2, [x22, #16]
+_check2
+    CMP     x23, #2
+    B.LT    _check1
+    LDR     x1, [x22, #8]
+_check1
+    CMP     x23, #1
+    B.LT    _do_call
+    LDR     x0, [x22]
 
-    ; Branch With Link to the ntdll function stub.
-    BLR     x10
+_do_call
+    MOV     x8, x21               ; move the syscall number into x8
+    BLR     x20                    ; call the function pointer
 
-    ; The syscall's return value is now in x0, the correct C return register.
-
-    ; Restore the saved registers
-    LDP     x19, x30, [sp], #16
-
-    ; Return to the C caller
+    MOV     sp, x19                ; restore the original stack pointer from x19
+    LDP     x23, x30, [sp], #16   ; restore x23 and link register
+    LDP     x21, x22, [sp], #16   ; restore x21, x22
+    LDP     x19, x20, [sp], #16   ; restore x19, x20
     RET
 
     ALIGN

--- a/dll/src/GateTrampolineARM64.asm
+++ b/dll/src/GateTrampolineARM64.asm
@@ -1,6 +1,12 @@
 ;
-; ARM64 Syscall Trampoline for Reflective DLL Injection
-; Microsoft ARM64 Assembler (armasm64.exe) syntax.
+; GateTrampolineARM64.s
+;
+; DoSyscall function implementation for 64-bit Windows on ARM64 to perform system calls with arguments passed as an array.
+;  NTSTATUS DoSyscall(VOID *fn, DWORD dwSyscallNr, ULONG_PTR *lpArgs, DWORD dwNumberOfArgs);
+;
+; Authors:
+;  Alex "xaitax" Hagenah                            - Original implementation
+;  Diego Ledda <diego_ledda[at]rapid7[dot]com>      - Argument as array porting and cleanup
 ;
     AREA    |.text|, CODE, READONLY, ALIGN=3
     EXPORT  DoSyscall

--- a/dll/src/ReflectiveLoader.c
+++ b/dll/src/ReflectiveLoader.c
@@ -25,8 +25,10 @@
 // OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //===============================================================================================//
-#pragma optimize("", off)
-#pragma clang optimize off
+// #ifdef ARKARI_OBFUSCATOR
+// #pragma optimize("", off)
+// #pragma clang optimize off
+// #endif
 #include "ReflectiveLoader.h"
 #include "DirectSyscall.c"
 
@@ -115,7 +117,7 @@ typedef struct
 //===============================================================================================//
 
 // STEP 0: Finds the loader's own image base in memory by searching backwards from the caller's address.
-static NO_OBF ULONG_PTR _find_image_base(VOID)
+static COMPILER_OPTIONS ULONG_PTR _find_image_base(VOID)
 {
 	ULONG_PTR uiLibraryAddress = caller();
 	while (TRUE)
@@ -136,7 +138,7 @@ static NO_OBF ULONG_PTR _find_image_base(VOID)
 }
 
 // STEP 1: Resolves all required functions and prepares for direct syscalls.
-static NO_OBF DWORD _resolve_dependencies(PLOADER_CONTEXT pContext)
+static COMPILER_OPTIONS DWORD _resolve_dependencies(PLOADER_CONTEXT pContext)
 {
 	ULONG_PTR uiBaseAddress;
 	USHORT usCounter;
@@ -259,7 +261,7 @@ static NO_OBF DWORD _resolve_dependencies(PLOADER_CONTEXT pContext)
 	return RDI_SUCCESS;
 }
 
-static NO_OBF BOOL _load_image_into_memory(PLOADER_CONTEXT pContext)
+static COMPILER_OPTIONS BOOL _load_image_into_memory(PLOADER_CONTEXT pContext)
 {
 	SIZE_T RegionSize = pContext->pNtHeaders->OptionalHeader.SizeOfImage;
 
@@ -296,7 +298,7 @@ static NO_OBF BOOL _load_image_into_memory(PLOADER_CONTEXT pContext)
 }
 
 // STEP 4: Process the image's Import Address Table (IAT).
-static NO_OBF void _process_imports(PLOADER_CONTEXT pContext)
+static COMPILER_OPTIONS void _process_imports(PLOADER_CONTEXT pContext)
 {
 	PIMAGE_DATA_DIRECTORY pDataDirectory = &pContext->pNtHeaders->OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_IMPORT];
 	if (pDataDirectory->Size == 0)
@@ -338,7 +340,7 @@ static NO_OBF void _process_imports(PLOADER_CONTEXT pContext)
 }
 
 // STEP 5: Process the image's base relocations.
-static NO_OBF void _process_relocations(PLOADER_CONTEXT pContext)
+static COMPILER_OPTIONS void _process_relocations(PLOADER_CONTEXT pContext)
 {
 	ULONG_PTR uiDelta = pContext->uiBaseAddress - pContext->pNtHeaders->OptionalHeader.ImageBase;
 	if (uiDelta == 0)
@@ -408,7 +410,7 @@ static NO_OBF void _process_relocations(PLOADER_CONTEXT pContext)
 }
 
 // STEP 6: Set the correct memory protections on each section of the newly loaded image.
-static NO_OBF void _set_memory_protections(PLOADER_CONTEXT pContext)
+static COMPILER_OPTIONS void _set_memory_protections(PLOADER_CONTEXT pContext)
 {
 	PIMAGE_SECTION_HEADER pSectionHeader = IMAGE_FIRST_SECTION(pContext->pNtHeaders);
 	for (USHORT i = 0; i < pContext->pNtHeaders->FileHeader.NumberOfSections; i++, pSectionHeader++)
@@ -446,7 +448,7 @@ static NO_OBF void _set_memory_protections(PLOADER_CONTEXT pContext)
 }
 
 // STEP 7 & 8: Call the image's entry point and return its address.
-static NO_OBF ULONG_PTR _call_entry_point(PLOADER_CONTEXT pContext, LPVOID lpParameter)
+static COMPILER_OPTIONS ULONG_PTR _call_entry_point(PLOADER_CONTEXT pContext, LPVOID lpParameter)
 {
 	// Get the address of the entry point.
 	ULONG_PTR pEntryPoint = (pContext->uiBaseAddress + pContext->pNtHeaders->OptionalHeader.AddressOfEntryPoint);
@@ -472,9 +474,9 @@ static NO_OBF ULONG_PTR _call_entry_point(PLOADER_CONTEXT pContext, LPVOID lpPar
 // By explicitly declaring the loader as __cdecl, we ensure the name is exported simply
 // as "ReflectiveLoader" on all platforms, which is what the injector expects.
 #ifdef REFLECTIVEDLLINJECTION_VIA_LOADREMOTELIBRARYR
-RDIDLLEXPORT NO_OBF ULONG_PTR __cdecl ReflectiveLoader(LPVOID lpParameter)
+RDIDLLEXPORT COMPILER_OPTIONS ULONG_PTR __cdecl ReflectiveLoader(LPVOID lpParameter)
 #else
-RDIDLLEXPORT NO_OBF ULONG_PTR WINAPI ReflectiveLoader(VOID)
+RDIDLLEXPORT COMPILER_OPTIONS ULONG_PTR WINAPI ReflectiveLoader(VOID)
 #endif
 {
 	// NOTE:    Using SecureZeroMemory instead of `LOADER_CONTEXT context = { 0 }` because of segmentfault in metsrv.
@@ -538,7 +540,7 @@ RDIDLLEXPORT NO_OBF ULONG_PTR WINAPI ReflectiveLoader(VOID)
 
 #ifndef REFLECTIVEDLLINJECTION_CUSTOM_DLLMAIN
 // Default DllMain if the user does not supply their own.
-NO_OBF BOOL  WINAPI DllMain(HINSTANCE hinstDLL, DWORD dwReason, LPVOID lpReserved)
+COMPILER_OPTIONS BOOL  WINAPI DllMain(HINSTANCE hinstDLL, DWORD dwReason, LPVOID lpReserved)
 {
 	BOOL bReturnValue = TRUE;
 	switch (dwReason)

--- a/dll/src/ReflectiveLoader.c
+++ b/dll/src/ReflectiveLoader.c
@@ -25,7 +25,8 @@
 // OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //===============================================================================================//
-
+#pragma optimize("", off)
+#pragma clang optimize off
 #include "ReflectiveLoader.h"
 #include "DirectSyscall.c"
 
@@ -114,7 +115,7 @@ typedef struct
 //===============================================================================================//
 
 // STEP 0: Finds the loader's own image base in memory by searching backwards from the caller's address.
-static ULONG_PTR _find_image_base(VOID)
+static NO_OBF ULONG_PTR _find_image_base(VOID)
 {
 	ULONG_PTR uiLibraryAddress = caller();
 	while (TRUE)
@@ -135,7 +136,7 @@ static ULONG_PTR _find_image_base(VOID)
 }
 
 // STEP 1: Resolves all required functions and prepares for direct syscalls.
-static DWORD _resolve_dependencies(PLOADER_CONTEXT pContext)
+static NO_OBF DWORD _resolve_dependencies(PLOADER_CONTEXT pContext)
 {
 	ULONG_PTR uiBaseAddress;
 	USHORT usCounter;
@@ -258,7 +259,7 @@ static DWORD _resolve_dependencies(PLOADER_CONTEXT pContext)
 	return RDI_SUCCESS;
 }
 
-static BOOL _load_image_into_memory(PLOADER_CONTEXT pContext)
+static NO_OBF BOOL _load_image_into_memory(PLOADER_CONTEXT pContext)
 {
 	SIZE_T RegionSize = pContext->pNtHeaders->OptionalHeader.SizeOfImage;
 
@@ -295,7 +296,7 @@ static BOOL _load_image_into_memory(PLOADER_CONTEXT pContext)
 }
 
 // STEP 4: Process the image's Import Address Table (IAT).
-static void _process_imports(PLOADER_CONTEXT pContext)
+static NO_OBF void _process_imports(PLOADER_CONTEXT pContext)
 {
 	PIMAGE_DATA_DIRECTORY pDataDirectory = &pContext->pNtHeaders->OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_IMPORT];
 	if (pDataDirectory->Size == 0)
@@ -337,7 +338,7 @@ static void _process_imports(PLOADER_CONTEXT pContext)
 }
 
 // STEP 5: Process the image's base relocations.
-static void _process_relocations(PLOADER_CONTEXT pContext)
+static NO_OBF void _process_relocations(PLOADER_CONTEXT pContext)
 {
 	ULONG_PTR uiDelta = pContext->uiBaseAddress - pContext->pNtHeaders->OptionalHeader.ImageBase;
 	if (uiDelta == 0)
@@ -407,7 +408,7 @@ static void _process_relocations(PLOADER_CONTEXT pContext)
 }
 
 // STEP 6: Set the correct memory protections on each section of the newly loaded image.
-static void _set_memory_protections(PLOADER_CONTEXT pContext)
+static NO_OBF void _set_memory_protections(PLOADER_CONTEXT pContext)
 {
 	PIMAGE_SECTION_HEADER pSectionHeader = IMAGE_FIRST_SECTION(pContext->pNtHeaders);
 	for (USHORT i = 0; i < pContext->pNtHeaders->FileHeader.NumberOfSections; i++, pSectionHeader++)
@@ -445,7 +446,7 @@ static void _set_memory_protections(PLOADER_CONTEXT pContext)
 }
 
 // STEP 7 & 8: Call the image's entry point and return its address.
-static ULONG_PTR _call_entry_point(PLOADER_CONTEXT pContext, LPVOID lpParameter)
+static NO_OBF ULONG_PTR _call_entry_point(PLOADER_CONTEXT pContext, LPVOID lpParameter)
 {
 	// Get the address of the entry point.
 	ULONG_PTR pEntryPoint = (pContext->uiBaseAddress + pContext->pNtHeaders->OptionalHeader.AddressOfEntryPoint);
@@ -471,9 +472,9 @@ static ULONG_PTR _call_entry_point(PLOADER_CONTEXT pContext, LPVOID lpParameter)
 // By explicitly declaring the loader as __cdecl, we ensure the name is exported simply
 // as "ReflectiveLoader" on all platforms, which is what the injector expects.
 #ifdef REFLECTIVEDLLINJECTION_VIA_LOADREMOTELIBRARYR
-RDIDLLEXPORT ULONG_PTR __cdecl ReflectiveLoader(LPVOID lpParameter)
+RDIDLLEXPORT NO_OBF ULONG_PTR __cdecl ReflectiveLoader(LPVOID lpParameter)
 #else
-RDIDLLEXPORT ULONG_PTR WINAPI ReflectiveLoader(VOID)
+RDIDLLEXPORT NO_OBF ULONG_PTR WINAPI ReflectiveLoader(VOID)
 #endif
 {
 	// NOTE:    Using SecureZeroMemory instead of `LOADER_CONTEXT context = { 0 }` because of segmentfault in metsrv.
@@ -537,7 +538,7 @@ RDIDLLEXPORT ULONG_PTR WINAPI ReflectiveLoader(VOID)
 
 #ifndef REFLECTIVEDLLINJECTION_CUSTOM_DLLMAIN
 // Default DllMain if the user does not supply their own.
-BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD dwReason, LPVOID lpReserved)
+NO_OBF BOOL  WINAPI DllMain(HINSTANCE hinstDLL, DWORD dwReason, LPVOID lpReserved)
 {
 	BOOL bReturnValue = TRUE;
 	switch (dwReason)


### PR DESCRIPTION
This PR updates the ReflectiveDLLInjection:

- [x] Disable optimizations for Arkari (commented for now)
- [x] Adds obfuscation disable attributes for Arkari
- [x] Modify the `DoSyscall` and the `SyscallStub` to use a new format
- [x] Updates Direct Syscall stubs

## Why
Current implementation of the direct syscall fails on the DoSyscall function, most likely due to compiler-specific assumptions for example like the previous stack frame location `dll/src/GateTrampoline64.s:12`.
This PR updates the way we trigger the syscall, going from a parameters passthrough function to an array-to-parameters type of function.

The `DoSyscall` now receive a `ULONG_PTR **` array of args, used to store the parameters. Then the function is responsible to setup the stack arguments properly, and setup the remaining arguments to registers. and perform the call to the `syscall` instruction location after honoring the the syscall-number setup on eax and moving `rcx to r10`.